### PR TITLE
Bugfix: Ensures that the `_G` is initialized

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -1,5 +1,5 @@
-ADDON_COLOR_CODE = "|cffff7800"
-ACHIEVEMENT_COLOR_CODE = "|cffffff00";
+local ADDON_COLOR_CODE = "|cffff7800"
+local ACHIEVEMENT_COLOR_CODE = "|cffffff00";
 local addonPrefix = ADDON_COLOR_CODE.."[WOW-HC.com]: "..FONT_COLOR_CODE_CLOSE
 
 local function printAchievementInfo(achievement, message)
@@ -7,7 +7,6 @@ local function printAchievementInfo(achievement, message)
     DEFAULT_CHAT_FRAME:AddMessage(addonPrefix..achievementMsg..message..FONT_COLOR_CODE_CLOSE)
 end
 
-local _G = getfenv(0)
 local function hooksecurefunc(arg1, arg2, arg3)
     if type(arg1) == "string" then
         arg1, arg2, arg3 = _G, arg1, arg2
@@ -22,7 +21,7 @@ local function hooksecurefunc(arg1, arg2, arg3)
     end
 end
 
-BlizzardFunctions = {}
+local BlizzardFunctions = {}
 BlizzardFunctions.AcceptGroup = AcceptGroup
 BlizzardFunctions.InviteUnit = InviteUnit -- Retail
 BlizzardFunctions.InviteByName = InviteByName -- 1.12

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -7,6 +7,7 @@ local function printAchievementInfo(achievement, message)
     DEFAULT_CHAT_FRAME:AddMessage(addonPrefix..achievementMsg..message..FONT_COLOR_CODE_CLOSE)
 end
 
+local _G = getfenv(0)
 local function hooksecurefunc(arg1, arg2, arg3)
     if type(arg1) == "string" then
         arg1, arg2, arg3 = _G, arg1, arg2

--- a/Init.lua
+++ b/Init.lua
@@ -18,8 +18,6 @@ end
 
 
 local eventFrame1 = CreateFrame("Frame")
-eventFrame1:RegisterEvent("VARIABLES_LOADED")
-eventFrame1:SetScript("OnEvent", function(self, event, arg1)
 eventFrame1:RegisterEvent("ADDON_LOADED")
 eventFrame1:SetScript("OnEvent", function(self, event, addonName)
     addonName = addonName or arg1

--- a/Init.lua
+++ b/Init.lua
@@ -20,6 +20,12 @@ end
 local eventFrame1 = CreateFrame("Frame")
 eventFrame1:RegisterEvent("VARIABLES_LOADED")
 eventFrame1:SetScript("OnEvent", function(self, event, arg1)
+eventFrame1:RegisterEvent("ADDON_LOADED")
+eventFrame1:SetScript("OnEvent", function(self, event, addonName)
+    addonName = addonName or arg1
+    if addonName ~= "WOW_HC" then
+        return
+    end
 
     local version = GetBuildInfo()
     if (version == "1.12.0" or version == "1.12.1") then


### PR DESCRIPTION
- Ensure `_G` is initialized even when the `Gatherer` addon is not installed to set it globally.
- Use `ADDON_LOADED` instead of `VARIABLES_LOADED` as that is the correct event to listen for according to [documentation ](https://wowpedia.fandom.com/wiki/ADDON_LOADED)and all other addons
- Made more variables local to avoid side effects in other addons