### PR TITLE
Added real Achievement links to personal and whisper messages

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -1,9 +1,13 @@
 local ADDON_COLOR_CODE = "|cffff7800"
-local ACHIEVEMENT_COLOR_CODE = "|cffffff00";
 local addonPrefix = ADDON_COLOR_CODE.."[WOW-HC.com]: "..FONT_COLOR_CODE_CLOSE
 
-local function printAchievementInfo(achievement, message)
-    local achievementMsg = ACHIEVEMENT_COLOR_CODE..achievement..HIGHLIGHT_FONT_COLOR_CODE.." Achievement active. "
+local ACHIEVEMENT_COLOR_CODE = "|cffff8000";
+local function achievementLink(achievement)
+    return ACHIEVEMENT_COLOR_CODE.."|Hitem:"..achievement.itemId..":0:0:0|h["..achievement.name.."]|h"..FONT_COLOR_CODE_CLOSE
+end
+
+local function printAchievementInfo(link, message)
+    local achievementMsg = link..HIGHLIGHT_FONT_COLOR_CODE.." Achievement active. "
     DEFAULT_CHAT_FRAME:AddMessage(addonPrefix..achievementMsg..message..FONT_COLOR_CODE_CLOSE)
 end
 
@@ -28,7 +32,7 @@ BlizzardFunctions.InviteUnit = InviteUnit -- Retail
 BlizzardFunctions.InviteByName = InviteByName -- 1.12
 
 --region ====== Lone Wolf ======
-local LONE_WOLF_ACHIEVEMENT = "[Lone Wolf]"
+local loneWolfLink = achievementLink(TabAchievements[ACHIEVEMENT_LONE_WOLF])
 -- Disables right-click menu "Invite" button
 hooksecurefunc("UnitPopup_OnUpdate", function(self, dropdownMenu, which, unit, name)
     if WhcAddonSettings.blockInvites == 1 then
@@ -67,13 +71,13 @@ local inviteEventHandler = CreateFrame("Frame")
 inviteEventHandler:SetScript("OnEvent", function(self, event, name)
     DeclineGroup()
     StaticPopup_Hide("PARTY_INVITE"); -- Needed to remove the popup
-    printAchievementInfo(LONE_WOLF_ACHIEVEMENT, "Group invite auto declined.")
+    printAchievementInfo(loneWolfLink, "Group invite auto declined.")
 
     local playerName = arg1
     if RETAIL == 1 then
         playerName = name
     end
-    SendChatMessage("I am on the "..LONE_WOLF_ACHIEVEMENT.." achievement. I cannot group with other players.", "WHISPER", GetDefaultLanguage(), playerName)
+    SendChatMessage("I am on the "..loneWolfLink.." achievement. I cannot group with other players.", "WHISPER", GetDefaultLanguage(), playerName)
 end)
 
 function SetBlockInvites()
@@ -85,7 +89,7 @@ function SetBlockInvites()
 
         -- blocks outgoing invites via /i <char_name>
         local blockInvites = function(name)
-            printAchievementInfo(LONE_WOLF_ACHIEVEMENT, "Group invite is blocked.")
+            printAchievementInfo(loneWolfLink, "Group invite is blocked.")
         end
         InviteUnit = blockInvites
         InviteByName = blockInvites

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -1,7 +1,6 @@
-local ADDON_COLOR_CODE = "|cffff7800"
-local addonPrefix = ADDON_COLOR_CODE.."[WOW-HC.com]: "..FONT_COLOR_CODE_CLOSE
-
 local ACHIEVEMENT_COLOR_CODE = "|cffff8000";
+local addonPrefix = ACHIEVEMENT_COLOR_CODE.."[WOW-HC.com]: "..FONT_COLOR_CODE_CLOSE
+
 local function achievementLink(achievement)
     return ACHIEVEMENT_COLOR_CODE.."|Hitem:"..achievement.itemId..":0:0:0|h["..achievement.name.."]|h"..FONT_COLOR_CODE_CLOSE
 end

--- a/Tabs/Achievements.lua
+++ b/Tabs/Achievements.lua
@@ -112,26 +112,47 @@ end
 
 UIachievements = {}
 
-local tabAchievements = {
-    { id = 16384, icon = "spell_shadow_unsummonbuilding",       name = "Demon Slayer",           desc = "Reach level 60 only by killing demons." },
-
-    { id = 4096,  icon = "spell_nature_strengthofearthtotem02", name = "Grounded",               desc = "Reach level 60 without ever using flying services." },
-    { id = 64,    icon = "inv_misc_note_02",                    name = "Help Yourself",          desc = "Reach level 60 without ever turning in a quest (class and profession quests allowed)." },
-    { id = 1,     icon = "trade_blacksmithing",                 name = "Iron Bones",             desc = "Reach level 60 without ever repairing the durability of an item." },
-
-    { id = 4,     icon = "inv_misc_coin_03",                    name = "Killer Trader",          desc = "Reach level 60 without ever using the auction house to sell an item." },
-    { id = 32768, icon = "spell_holy_holynova",                 name = "Lightbringer",           desc = "Reach level 60 only by killing undead creatures." },
-    { id = 2048,  icon = "spell_nature_spiritwolf",             name = "Lone Wolf",              desc = "Reach level 60 without ever grouping with other players." },
-    { id = 256,   icon = "inv_gizmo_rocketboot_01",             name = "Marathon Runner",        desc = "Reach level 60 without ever learning a riding skill." },
-    { id = 128,   icon = "inv_shirt_white_01",                  name = "Mister White",           desc = "Reach level 60 without ever equipping an uncommon or greater quality item (only white and grey items allowed)." },
-    { id = 8,     icon = "inv_box_01",                          name = "My precious!",           desc = "Reach level 60 without ever trading goods or money with another player." },
-    { id = 32,    icon = "inv_pants_wolf",                      name = "Only Fan",               desc = "Reach level 60 without ever equipping anything other than weapons, shields, ammos, tabards or bags." },
-    { id = 8192,  icon = "inv_hammer_20",                       name = "Self-made",              desc = "Reach level 60 without ever equipping items that you did not craft yourself." },
-    { id = 1024,  icon = "spell_holy_layonhands",               name = "Soft Hands",             desc = "Reach level 60 without ever learning any primary profession." },
-    { id = 16,    icon = "inv_crate_03",                        name = "Special Deliveries",     desc = "Reach level 60 without ever getting goods or money from the mail (Simple letters and NPC quest/items are allowed)." },
-    { id = 512,   icon = "ability_hunter_pet_boar",             name = "That Which Has No Life", desc = "Reach level 60 only by killing boars or quilboars." },
-    { id = 2,     icon = "inv_misc_coin_05",                    name = "Time is money",          desc = "Reach level 60 without ever using the auction house to buy an item." },
+ACHIEVEMENT_DEMON_SLAYER           = 16384
+ACHIEVEMENT_GROUNDED               = 4096
+ACHIEVEMENT_HELP_YOURSELF          = 64
+ACHIEVEMENT_IRON_BONES             = 1
+ACHIEVEMENT_KILLER_TRADER          = 4
+ACHIEVEMENT_LIGHTBRINGER           = 32768
+ACHIEVEMENT_LONE_WOLF              = 2048
+ACHIEVEMENT_MARATHON_RUNNER        = 256
+ACHIEVEMENT_MISTER_WHITE           = 128
+ACHIEVEMENT_MY_PRECIOUS            = 8
+ACHIEVEMENT_ONLY_FAN               = 32
+ACHIEVEMENT_SELF_MADE              = 8192
+ACHIEVEMENT_SOFT_HANDS             = 1024
+ACHIEVEMENT_SPECIAL_DELIVERIES     = 16
+ACHIEVEMENT_THAT_WHICH_HAS_NO_LIFE = 512
+ACHIEVEMENT_TIME_IS_MONEY          = 2
+TabAchievements = {
+    [16384] = { icon = "spell_shadow_unsummonbuilding",       itemId = "707016", name = "Demon Slayer",           desc = "Reach level 60 only by killing demons." },
+    [4096]  = { icon = "spell_nature_strengthofearthtotem02", itemId = "707014", name = "Grounded",               desc = "Reach level 60 without ever using flying services." },
+    [64]    = { icon = "inv_misc_note_02",                    itemId = "707006", name = "Help Yourself",          desc = "Reach level 60 without ever turning in a quest (class and profession quests allowed)." },
+    [1]     = { icon = "trade_blacksmithing",                 itemId = "707000", name = "Iron Bones",             desc = "Reach level 60 without ever repairing the durability of an item." },
+    [4]     = { icon = "inv_misc_coin_03",                    itemId = "707002", name = "Killer Trader",          desc = "Reach level 60 without ever using the auction house to sell an item." },
+    [32768] = { icon = "spell_holy_holynova",                 itemId = "707017", name = "Lightbringer",           desc = "Reach level 60 only by killing undead creatures." },
+    [2048]  = { icon = "spell_nature_spiritwolf",             itemId = "707013", name = "Lone Wolf",              desc = "Reach level 60 without ever grouping with other players." },
+    [256]   = { icon = "inv_gizmo_rocketboot_01",             itemId = "707010", name = "Marathon Runner",        desc = "Reach level 60 without ever learning a riding skill." },
+    [128]   = { icon = "inv_shirt_white_01",                  itemId = "707007", name = "Mister White",           desc = "Reach level 60 without ever equipping an uncommon or greater quality item (only white and grey items allowed)." },
+    [8]     = { icon = "inv_box_01",                          itemId = "707003", name = "My precious!",           desc = "Reach level 60 without ever trading goods or money with another player." },
+    [32]    = { icon = "inv_pants_wolf",                      itemId = "707005", name = "Only Fan",               desc = "Reach level 60 without ever equipping anything other than weapons, shields, ammos, tabards or bags." },
+    [8192]  = { icon = "inv_hammer_20",                       itemId = "707015", name = "Self-made",              desc = "Reach level 60 without ever equipping items that you did not craft yourself." },
+    [1024]  = { icon = "spell_holy_layonhands",               itemId = "707012", name = "Soft Hands",             desc = "Reach level 60 without ever learning any primary profession." },
+    [16]    = { icon = "inv_crate_03",                        itemId = "707004", name = "Special Deliveries",     desc = "Reach level 60 without ever getting goods or money from the mail (Simple letters and NPC quest/items are allowed)." },
+    [512]   = { icon = "ability_hunter_pet_boar",             itemId = "707011", name = "That Which Has No Life", desc = "Reach level 60 only by killing boars or quilboars." },
+    [2]     = { icon = "inv_misc_coin_05",                    itemId = "707001", name = "Time is money",          desc = "Reach level 60 without ever using the auction house to buy an item." },
 }
+local sortedAchievements = {}
+for id, data in pairs(TabAchievements) do
+    table.insert(sortedAchievements, { id = id, data = data })
+end
+table.sort(sortedAchievements, function(a, b)
+    return a.data.name < b.data.name  -- Sort alphabetically by name
+end)
 
 function tab_achievements(content)
     local title = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
@@ -173,18 +194,10 @@ function tab_achievements(content)
     scrollContent:SetHeight(800)
     scrollFrame:SetScrollChild(scrollContent) -- Attach the content frame to the scroll frame
 
-    local i = 0;
-    for key, value in pairs(tabAchievements) do
-        if (i == 0) then
-            y = -10
-        else
-            y = -10 + -(i * 53)
-        end
+    for i, value in ipairs(sortedAchievements) do
+        local y = -10 - 53 * (i-1)
 
-        itemSlot(scrollContent, 10, y, value.name, value.desc, value.icon, value.id);
-
-
-        i = i + 1
+        itemSlot(scrollContent, 10, y, value.data.name, value.data.desc, value.data.icon, value.id);
     end
 
     local desc2 = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")

--- a/WOW_HC.toc
+++ b/WOW_HC.toc
@@ -1,5 +1,5 @@
 ## Interface: 11200, 11201, 11203, 11303, 11304, 11305, 11306, 11307, 11400, 11401, 11402, 11403, 11404,
-## Title: |cffff7800WOW-HC.com|r
+## Title: |cffff8000WOW-HC.com|r
 ## Notes: Official WOW-HC addon
 ## Author: Nyu, DBFBlackbull(Windcaller)
 ## Version: 0.0


### PR DESCRIPTION
- Added real Achievement links to personal and whisper messages
- Refactored tabAchievements to be a proper table
- Added itemIDs to achievements table. These are used to create links
- Added an array with the achievements sorted in alphabetical order
- Simplified y index calculation for achievements
- Corrected WOW-HC.com color to be the real color of legenary items. This value was gotten from the 1.14 client using https://wowpedia.fandom.com/wiki/API_GetItemQualityColor