### PR TITLE
🧹 Refactor: Removed a lot of if-else statement by generalizing the logic 🧹 

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -107,7 +107,7 @@ local myPreciousLink = achievementLink(TabAchievements[ACHIEVEMENT_MY_PRECIOUS])
 function Whc_SetBlockTrades()
     InitiateTrade = BlizzardFunctions.InitiateTrade
 
-    -- Block incoming via Blizzard interface checkbox
+    -- Block incoming trade via Blizzard interface checkbox
     SetCVar("blockTrades", WhcAddonSettings.blockTrades)
     if WhcAddonSettings.blockTrades == 1 then
         -- Block outgoing trade

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -75,14 +75,16 @@ inviteEventHandler:SetScript("OnEvent", function(self, event, name)
     StaticPopup_Hide("PARTY_INVITE"); -- Needed to remove the popup
     printAchievementInfo(loneWolfLink, "Group invite auto declined.")
 
-    local playerName = arg1
-    if RETAIL == 1 then
-        playerName = name
-    end
-    SendChatMessage("I am on the "..loneWolfLink.." achievement. I cannot group with other players.", "WHISPER", GetDefaultLanguage(), playerName)
+    name = name or arg1
+    SendChatMessage("I am on the "..loneWolfLink.." achievement. I cannot group with other players.", "WHISPER", GetDefaultLanguage(), name)
 end)
 
 function Whc_SetBlockInvites()
+    inviteEventHandler:UnregisterEvent("PARTY_INVITE_REQUEST")
+    AcceptGroup = BlizzardFunctions.AcceptGroup
+    InviteUnit = BlizzardFunctions.InviteUnit
+    InviteByName = BlizzardFunctions.InviteByName
+
     if WhcAddonSettings.blockInvites == 1 then
         -- Blocks incoming invites
         inviteEventHandler:RegisterEvent("PARTY_INVITE_REQUEST")
@@ -95,11 +97,6 @@ function Whc_SetBlockInvites()
         end
         InviteUnit = blockInvites
         InviteByName = blockInvites
-    else
-        inviteEventHandler:UnregisterEvent("PARTY_INVITE_REQUEST")
-        AcceptGroup = BlizzardFunctions.AcceptGroup
-        InviteUnit = BlizzardFunctions.InviteUnit
-        InviteByName = BlizzardFunctions.InviteByName
     end
 end
 --endregion
@@ -108,6 +105,8 @@ end
 BlizzardFunctions.InitiateTrade = InitiateTrade
 local myPreciousLink = achievementLink(TabAchievements[ACHIEVEMENT_MY_PRECIOUS])
 function Whc_SetBlockTrades()
+    InitiateTrade = BlizzardFunctions.InitiateTrade
+
     -- Block incoming via Blizzard interface checkbox
     SetCVar("blockTrades", WhcAddonSettings.blockTrades)
     if WhcAddonSettings.blockTrades == 1 then
@@ -115,8 +114,6 @@ function Whc_SetBlockTrades()
         InitiateTrade = function()
             printAchievementInfo(myPreciousLink, "Trade requests are blocked.")
         end
-    else
-        InitiateTrade = BlizzardFunctions.InitiateTrade
     end
 end
 --endregion

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -43,9 +43,6 @@ hooksecurefunc("UnitPopup_OnUpdate", function(self, dropdownMenu, which, unit, n
 end)
 
 --region ====== Lone Wolf ======
-BlizzardFunctions.AcceptGroup = AcceptGroup
-BlizzardFunctions.InviteUnit = InviteUnit -- Retail
-BlizzardFunctions.InviteByName = InviteByName -- 1.12
 local loneWolfLink = achievementLink(TabAchievements[ACHIEVEMENT_LONE_WOLF])
 
 -- Disables friend list "Group Invite" button
@@ -79,7 +76,10 @@ inviteEventHandler:SetScript("OnEvent", function(self, event, name)
     SendChatMessage("I am on the "..loneWolfLink.." achievement. I cannot group with other players.", "WHISPER", GetDefaultLanguage(), name)
 end)
 
-function Whc_SetBlockInvites()
+BlizzardFunctions.AcceptGroup = AcceptGroup
+BlizzardFunctions.InviteUnit = InviteUnit -- Retail
+BlizzardFunctions.InviteByName = InviteByName -- 1.12
+function WHC.SetBlockInvites()
     inviteEventHandler:UnregisterEvent("PARTY_INVITE_REQUEST")
     AcceptGroup = BlizzardFunctions.AcceptGroup
     InviteUnit = BlizzardFunctions.InviteUnit
@@ -102,9 +102,10 @@ end
 --endregion
 
 --region ====== My precious! ======
-BlizzardFunctions.InitiateTrade = InitiateTrade
 local myPreciousLink = achievementLink(TabAchievements[ACHIEVEMENT_MY_PRECIOUS])
-function Whc_SetBlockTrades()
+
+BlizzardFunctions.InitiateTrade = InitiateTrade
+function WHC.SetBlockTrades()
     InitiateTrade = BlizzardFunctions.InitiateTrade
 
     -- Block incoming trade via Blizzard interface checkbox

--- a/Death.lua
+++ b/Death.lua
@@ -1,4 +1,4 @@
-function WHC_updateDeathWindow(pvp)
+function WHC.UpdateDeathWindow(pvp)
 
     if (pvp) then
 
@@ -22,10 +22,10 @@ function WHC_updateDeathWindow(pvp)
     end
 end
 
--- WHC_updateDeathWindow(false);
+-- WHC.UpdateDeathWindow(false);
 
 
-function WHC_showDeathWindow(show)
+local function showDeathWindow(show)
     if (RETAIL == 1) then
         StaticPopupDialogs["DEATH"].OnButton2 = function(data, reason)
             if (reason == "override") then
@@ -90,7 +90,7 @@ function WHC_showDeathWindow(show)
             -- copyButton:SetScript("OnClick", function()
             --     urlEditBox:HighlightText()
             --    urlEditBox:SetFocus()
-            --    DebugPrint("URL text selected. Please use Ctrl+C to copy.")
+            --    WHC.DebugPrint("URL text selected. Please use Ctrl+C to copy.")
             --end)
 
             -- Cancel button
@@ -101,7 +101,7 @@ function WHC_showDeathWindow(show)
             cancelButton:SetText("Back")
             cancelButton:SetScript("OnClick", function()
                 urlFrame:Hide()
-                WHC_showDeathWindow(true);
+                showDeathWindow(true);
             end)
 
             -- Show the frame
@@ -171,7 +171,7 @@ function WHC_showDeathWindow(show)
                 -- copyButton:SetScript("OnClick", function()
                 --     urlEditBox:HighlightText()
                 --    urlEditBox:SetFocus()
-                --    DebugPrint("URL text selected. Please use Ctrl+C to copy.")
+                --    WHC.DebugPrint("URL text selected. Please use Ctrl+C to copy.")
                 --end)
 
                 -- Cancel button
@@ -182,7 +182,7 @@ function WHC_showDeathWindow(show)
                 cancelButton:SetText("Back")
                 cancelButton:SetScript("OnClick", function()
                     urlFrame:Hide()
-                    WHC_showDeathWindow(true);
+                    showDeathWindow(true);
                 end)
 
                 -- Show the frame
@@ -196,4 +196,4 @@ function WHC_showDeathWindow(show)
     end
 end
 
-WHC_showDeathWindow(false);
+showDeathWindow(false);

--- a/Debug.lua
+++ b/Debug.lua
@@ -8,12 +8,12 @@ SlashCmdList["ReloadUI"] = function(msg, editbox)
 end
 
 -- Function to print debug messages
-function DebugPrint(message)
+function WHC.DebugPrint(message)
     DEFAULT_CHAT_FRAME:AddMessage(message)
 end
 
 -- Function to print table key values
-function DebugDump(o)
+function WHC.DebugDump(o)
     if type(o) == 'table' then
         local s = '{ '
         local idx = 0
@@ -26,17 +26,17 @@ function DebugDump(o)
             if idx > 0 then
                 s = s .. ', '
             end
-            s = s .. '['..key..'] = ' .. DebugDump(v)
+            s = s .. '['..key..'] = ' .. WHC.DebugDump(v)
             idx = idx + 1
         end
         return s .. '} '
     end
 
-    return DebugPrint(tostring(o))
+    return WHC.DebugPrint(tostring(o))
 end
 
 -- Print message when the addon is loaded
--- DebugPrint("ReleaseSpiritMod loaded.")
+-- WHC.DebugPrint("ReleaseSpiritMod loaded.")
 
 -- ChatFrame_AddMessageEventFilter(evt,myChatFilter)
 

--- a/Events.lua
+++ b/Events.lua
@@ -162,14 +162,12 @@ playerLogin:SetScript("OnEvent", function(self, event)
 
         local inInstance, instanceType = IsInInstance()
         if (instanceType == "PVP") then
-            WHC_updateDeathWindow(true)
+            WHC.UpdateDeathWindow(true)
         else
-            WHC_updateDeathWindow(false)
+            WHC.UpdateDeathWindow(false)
         end
     end
 end)
-
-
 
 
 ACHBtn = nil
@@ -211,9 +209,9 @@ local function characterSheetWOWHCbutton(frame, name)
         local index = value
         viewAchButton:SetScript("OnClick", function()
             if (name == "character") then
-                UIShowTabContent("Achievements")
+                WHC.UIShowTabContent("Achievements")
             else
-                UIShowTabContent("Achievements", UnitName("target"))
+                WHC.UIShowTabContent("Achievements", UnitName("target"))
             end
         end)
 
@@ -243,7 +241,6 @@ local function characterSheetWOWHCbutton(frame, name)
         end
     end
 end
-
 
 
 local auctionHouseEvents = CreateFrame("Frame")
@@ -292,9 +289,9 @@ mapChangeEventHandler:SetScript("OnEvent", function(self, event)
     local inInstance, instanceType = IsInInstance()
     -- message(instanceType)
     if (instanceType == "pvp") then
-        WHC_updateDeathWindow(true)
+        WHC.UpdateDeathWindow(true)
     else
-        WHC_updateDeathWindow(false)
+        WHC.UpdateDeathWindow(false)
     end
 end)
 
@@ -310,7 +307,7 @@ if (RETAIL == 1) then
         characterSheetWOWHCbutton(getglobal("CharacterFrame"), "character")
     end)
     CharacterFrame:HookScript("OnHide", function(self)
-        UIShowTabContent(0)
+        WHC.UIShowTabContent(0)
     end)
 else
     xx_CharacterFrame_ShowSubFrame = CharacterFrame_ShowSubFrame
@@ -328,13 +325,13 @@ else
 
     xx_CharacterFrame_OnHide = CharacterFrame_OnHide
     function CharacterFrame_OnHide()
-        UIShowTabContent(0)
+        WHC.UIShowTabContent(0)
         xx_CharacterFrame_OnHide()
     end
 end
 
 
-function handleChatEvent(arg1)
+local function handleChatEvent(arg1)
     if strfind(string.lower(arg1), string.lower("::whc::ticket:")) then
         local result = string.gsub(arg1, "::whc::ticket:", "")
 
@@ -572,10 +569,10 @@ function handleChatEvent(arg1)
     end
 end
 
-function handleMonsterChatEvent(arg1)
+local function handleMonsterChatEvent(arg1)
     if (strfind(string.lower(arg1), string.lower("has died at level"))) then
 
-        logDeathMessage(arg1)
+        WHC.LogDeathMessage(arg1)
         return 0
     else
         return 1

--- a/Init.lua
+++ b/Init.lua
@@ -17,9 +17,9 @@ end
 
 
 
-local eventFrame1 = CreateFrame("Frame")
-eventFrame1:RegisterEvent("ADDON_LOADED")
-eventFrame1:SetScript("OnEvent", function(self, event, addonName)
+WHC = CreateFrame("Frame")
+WHC:RegisterEvent("ADDON_LOADED")
+WHC:SetScript("OnEvent", function(self, event, addonName)
     addonName = addonName or arg1
     if addonName ~= "WOW_HC" then
         return
@@ -39,18 +39,18 @@ eventFrame1:SetScript("OnEvent", function(self, event, addonName)
         RETAIL_BACKDROP = nil
     end
 
-    initUI()
+    WHC.InitializeUI()
 
 
     if (RETAIL == 1) then
         -- todo (low prio since ticket status block not displayed on retail)
     else
         StaticPopupDialogs["HELP_TICKET"].OnAccept = function()
-            UIShowTabContent("Support")
+            WHC.UIShowTabContent("Support")
         end
 
         StaticPopupDialogs["HELP_TICKET"].OnCancel = function()
-            UIShowTabContent("Support")
+            WHC.UIShowTabContent("Support")
         end
     end
 
@@ -92,16 +92,16 @@ eventFrame1:SetScript("OnEvent", function(self, event, addonName)
     if (WhcAddonSettings.splash == 0) then
         WhcAddonSettings.splash = 1
 
-        UIShowTabContent("General")
+        WHC.UIShowTabContent("General")
     end
 
     if WhcAddonSettings.blockInvites == 1 then
-        Whc_SetBlockInvites()
+        WHC.SetBlockInvites()
     end
 
     if WhcAddonSettings.blockTrades == 1 then
-        Whc_SetBlockTrades()
+        WHC.SetBlockTrades()
     end
 
-  --    UIShowTabContent("PVP") -- todo remove
+  --    WHC.UIShowTabContent("PVP") -- todo remove
 end)

--- a/MinimapButton.lua
+++ b/MinimapButton.lua
@@ -1,4 +1,4 @@
-minimapIcon = CreateFrame('Button', "minimapIcon", Minimap)
+local minimapIcon = CreateFrame('Button', "minimapIcon", Minimap)
 
 minimapIcon:RegisterForDrag('LeftButton')
 minimapIcon:RegisterForClicks('LeftButtonUp', 'RightButtonUp')
@@ -16,9 +16,9 @@ minimapIcon:SetClampedToScreen(true)
 
 minimapIcon:SetScript("OnClick", function()
     if (UIframe:IsVisible()) then
-        UIShowTabContent(0)
+        WHC.UIShowTabContent(0)
     else
-        UIShowTabContent("General")
+        WHC.UIShowTabContent("General")
     end
 end)
 

--- a/RecentDeaths.lua
+++ b/RecentDeaths.lua
@@ -39,13 +39,59 @@ content:SetWidth(360)
 content:SetHeight(0)
 scrollFrame:SetScrollChild(content)
 
+local closeButton = CreateFrame("Button", nil, DeathLogFrame, "UIPanelCloseButton")
+closeButton:SetPoint("TOPRIGHT", DeathLogFrame, "TOPRIGHT", 2, 1)
+closeButton:SetWidth(36)
+closeButton:SetHeight(36)
+closeButton:SetText("Close")
+closeButton:SetScript("OnClick", function()
+    WhcAddonSettings.recentDeaths = 0
+    DeathLogFrame:Hide()
+end)
+
+
+local resizeButton = CreateFrame("Button", nil, DeathLogFrame)
+resizeButton:SetPoint("BOTTOMRIGHT", DeathLogFrame, "BOTTOMRIGHT", 2, -3)
+resizeButton:SetWidth(16)
+resizeButton:SetHeight(16)
+
+local function SetRotation(texture, angle)
+    local cos, sin = math.cos(angle), math.sin(angle)
+    texture:SetTexCoord(
+            0.5 - 0.5 * cos + 0.5 * sin, 0.5 - 0.5 * sin - 0.5 * cos,
+            0.5 + 0.5 * cos + 0.5 * sin, 0.5 + 0.5 * sin - 0.5 * cos,
+            0.5 - 0.5 * cos - 0.5 * sin, 0.5 - 0.5 * sin + 0.5 * cos,
+            0.5 + 0.5 * cos - 0.5 * sin, 0.5 + 0.5 * sin + 0.5 * cos
+    )
+end
+
+local resizeTexture = resizeButton:CreateTexture(nil, "BACKGROUND")
+resizeTexture:SetTexture("Interface\\ChatFrame\\ChatFrameExpandArrow")
+resizeTexture:SetWidth(9)
+resizeTexture:SetHeight(9)
+resizeTexture:SetPoint("CENTER", resizeButton, "CENTER", 0, 0)
+SetRotation(resizeTexture, math.rad(80))
+
+
+
+DeathLogFrame:SetResizable(true)
+DeathLogFrame:SetMinResize(10, 10)
+DeathLogFrame:SetMaxResize(800, 600)
+
+resizeButton:EnableMouse(true)
+resizeButton:SetScript("OnMouseDown", function(self, button)
+    DeathLogFrame:StartSizing("BOTTOMRIGHT")
+end)
+resizeButton:SetScript("OnMouseUp", function(self, button)
+    DeathLogFrame:StopMovingOrSizing()
+end)
 
 
 local deathMessages = {}
 local fontHeight = 14
 local messageRows = {} -- Table to store created font strings
 
-function logDeathMessage(msg)
+function WHC.LogDeathMessage(msg)
     if (WhcAddonSettings.recentDeaths == 1) then
         local serverTime = date("%H:%M")
         local formattedMessage = string.format("|cffFFFF00%s|r %s", serverTime, msg)
@@ -79,56 +125,3 @@ function logDeathMessage(msg)
         content:SetHeight(fontHeight * countRows)
     end
 end
-
-
-
-
-
-
-
-local closeButton = CreateFrame("Button", nil, DeathLogFrame, "UIPanelCloseButton")
-closeButton:SetPoint("TOPRIGHT", DeathLogFrame, "TOPRIGHT", 2, 1)
-closeButton:SetWidth(36)
-closeButton:SetHeight(36)
-closeButton:SetText("Close")
-closeButton:SetScript("OnClick", function()
-    WhcAddonSettings.recentDeaths = 0
-    DeathLogFrame:Hide()
-end)
-
-
-local resizeButton = CreateFrame("Button", nil, DeathLogFrame)
-resizeButton:SetPoint("BOTTOMRIGHT", DeathLogFrame, "BOTTOMRIGHT", 2, -3)
-resizeButton:SetWidth(16)
-resizeButton:SetHeight(16)
-
-local function SetRotation(texture, angle)
-    local cos, sin = math.cos(angle), math.sin(angle)
-    texture:SetTexCoord(
-        0.5 - 0.5 * cos + 0.5 * sin, 0.5 - 0.5 * sin - 0.5 * cos,
-        0.5 + 0.5 * cos + 0.5 * sin, 0.5 + 0.5 * sin - 0.5 * cos,
-        0.5 - 0.5 * cos - 0.5 * sin, 0.5 - 0.5 * sin + 0.5 * cos,
-        0.5 + 0.5 * cos - 0.5 * sin, 0.5 + 0.5 * sin + 0.5 * cos
-    )
-end
-
-local resizeTexture = resizeButton:CreateTexture(nil, "BACKGROUND")
-resizeTexture:SetTexture("Interface\\ChatFrame\\ChatFrameExpandArrow")
-resizeTexture:SetWidth(9)
-resizeTexture:SetHeight(9)
-resizeTexture:SetPoint("CENTER", resizeButton, "CENTER", 0, 0)
-SetRotation(resizeTexture, math.rad(80))
-
-
-
-DeathLogFrame:SetResizable(true)
-DeathLogFrame:SetMinResize(10, 10)
-DeathLogFrame:SetMaxResize(800, 600)
-
-resizeButton:EnableMouse(true)
-resizeButton:SetScript("OnMouseDown", function(self, button)
-    DeathLogFrame:StartSizing("BOTTOMRIGHT")
-end)
-resizeButton:SetScript("OnMouseUp", function(self, button)
-    DeathLogFrame:StopMovingOrSizing()
-end)

--- a/RecentDeaths.lua
+++ b/RecentDeaths.lua
@@ -46,6 +46,7 @@ closeButton:SetHeight(36)
 closeButton:SetText("Close")
 closeButton:SetScript("OnClick", function()
     WhcAddonSettings.recentDeaths = 0
+    WHC_SETTINGS.recentDeathsBtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.recentDeaths))
     DeathLogFrame:Hide()
 end)
 

--- a/Support.lua
+++ b/Support.lua
@@ -2,9 +2,9 @@ local originalHelpButton_OnClick = HelpMicroButton:GetScript("OnClick")
 
 HelpMicroButton:SetScript("OnClick", function()
     if UIframe:IsVisible() then
-        UIShowTabContent(0)
+        WHC.UIShowTabContent(0)
     else
-        UIShowTabContent("Support")
+        WHC.UIShowTabContent("Support")
     end
 end)
 

--- a/Tabs/Achievements.lua
+++ b/Tabs/Achievements.lua
@@ -154,7 +154,7 @@ table.sort(sortedAchievements, function(a, b)
     return a.data.name < b.data.name  -- Sort alphabetically by name
 end)
 
-function tab_achievements(content)
+function WHC.Tab_Achievements(content)
     local title = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     title:SetPoint("TOP", content, "TOP", 0, -10) -- Adjust y-offset based on logo size
     title:SetText("Achievements")

--- a/Tabs/General.lua
+++ b/Tabs/General.lua
@@ -1,5 +1,4 @@
-
-function mathMod(a, b)
+local function mathMod(a, b)
     return a - b * math.floor(a / b)
 end
 
@@ -66,7 +65,7 @@ local tabInfos = {
     { id = 5, icon = "mag",    name = "Mak'gora",           desc = "Challenge players to a Duel to the Death by typing the |cffffd200.makgora|r command\n\nIf the challenged player accepts, you will fight to the death until only one remains.\n\nFleeing a Mak'gora will result in your immediate execution." },
 }
 
-function tab_general(content)
+function WHC.Tab_General(content)
     local wowhclinkbtn = CreateFrame("Button", "WowhcBtn", content)
 
     wowhclinkbtn:SetWidth(28)

--- a/Tabs/PVP.lua
+++ b/Tabs/PVP.lua
@@ -146,7 +146,7 @@ UIspecialEvent = nil
 UIWS = nil
 UIAB = nil
 UIAV = nil
-function tab_PVP(content)
+function WHC.Tab_PVP(content)
     bgSlot(content, 0, "warsong", "Warsong Gulch",
         "As a 10 vs 10 capture-the-flag battleground, the first faction to capture three flags is victorious")
 

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -34,7 +34,7 @@ local function createSettingsCheckBox(contentFrame, text)
     return checkBox
 end
 
-function tab_settings(content)
+function WHC.Tab_settings(content)
     createTitle(content, "Settings", 18)
 
     WHC_SETTINGS.minimap = createSettingsCheckBox(content, "Display minimap button")

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -1,9 +1,37 @@
 WHC_SETTINGS = {}
 
 local offsetY = 20
-function getNextOffsetY()
+local function getNextOffsetY()
     offsetY = offsetY - 30
     return offsetY
+end
+
+local function createTitle(contentFrame, text, fontSize)
+    local title = contentFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    title:SetPoint("TOP", contentFrame, "TOP", 0, getNextOffsetY()) -- Adjust y-offset based on logo size
+    title:SetText(text)
+    title:SetFont("Fonts\\FRIZQT__.TTF", fontSize)
+    title:SetTextColor(0.933, 0.765, 0)
+end
+
+local function createSettingsCheckBox(contentFrame, text)
+    local settingsFrame = CreateFrame("Frame", "MySettingsFrame", contentFrame)
+    settingsFrame:SetWidth(200)
+    settingsFrame:SetHeight(100)
+    settingsFrame:SetPoint("TOPLEFT", contentFrame, "TOPLEFT", 30, getNextOffsetY())
+
+    local checkBox = CreateFrame("CheckButton", "MyCheckBox", settingsFrame, "UICheckButtonTemplate")
+    checkBox:SetWidth(24)
+    checkBox:SetHeight(24)
+    checkBox:SetPoint("TOPLEFT", settingsFrame, "TOPLEFT", 10, -10)
+
+    local checkBoxTitle = checkBox:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    checkBoxTitle:SetPoint("TOPLEFT", checkBox, "TOPLEFT", 25, -5) -- Adjust y-offset based on logo size
+    checkBoxTitle:SetText(text)
+    checkBoxTitle:SetFont("Fonts\\FRIZQT__.TTF", 12)
+    checkBoxTitle:SetTextColor(0.933, 0.765, 0)
+
+    return checkBox
 end
 
 function tab_settings(content)
@@ -50,42 +78,14 @@ function tab_settings(content)
     WHC_SETTINGS.blockInvitesCheckbox = createSettingsCheckBox(content, "[Lone Wolf] Achievement: Block invites")
     WHC_SETTINGS.blockInvitesCheckbox:SetScript("OnClick", function(self)
         WhcAddonSettings.blockInvites = math.abs(WhcAddonSettings.blockInvites - 1)
-        Whc_SetBlockInvites()
+        WHC.SetBlockInvites()
     end)
 
     WHC_SETTINGS.blockTradesCheckbox = createSettingsCheckBox(content, "[My Precious!] Achievement: Block trades")
     WHC_SETTINGS.blockTradesCheckbox:SetScript("OnClick", function(self)
         WhcAddonSettings.blockTrades = math.abs(WhcAddonSettings.blockTrades - 1)
-        Whc_SetBlockTrades()
+        WHC.SetBlockTrades()
     end)
 
     return content;
-end
-
-function createTitle(contentFrame, text, fontSize)
-    local title = contentFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-    title:SetPoint("TOP", contentFrame, "TOP", 0, getNextOffsetY()) -- Adjust y-offset based on logo size
-    title:SetText(text)
-    title:SetFont("Fonts\\FRIZQT__.TTF", fontSize)
-    title:SetTextColor(0.933, 0.765, 0)
-end
-
-function createSettingsCheckBox(contentFrame, text)
-    local settingsFrame = CreateFrame("Frame", "MySettingsFrame", contentFrame)
-    settingsFrame:SetWidth(200)
-    settingsFrame:SetHeight(100)
-    settingsFrame:SetPoint("TOPLEFT", contentFrame, "TOPLEFT", 30, getNextOffsetY())
-
-    local checkBox = CreateFrame("CheckButton", "MyCheckBox", settingsFrame, "UICheckButtonTemplate")
-    checkBox:SetWidth(24)
-    checkBox:SetHeight(24)
-    checkBox:SetPoint("TOPLEFT", settingsFrame, "TOPLEFT", 10, -10)
-
-    local checkBoxTitle = checkBox:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-    checkBoxTitle:SetPoint("TOPLEFT", checkBox, "TOPLEFT", 25, -5) -- Adjust y-offset based on logo size
-    checkBoxTitle:SetText(text)
-    checkBoxTitle:SetFont("Fonts\\FRIZQT__.TTF", 12)
-    checkBoxTitle:SetTextColor(0.933, 0.765, 0)
-
-    return checkBox
 end

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -9,77 +9,55 @@ end
 function tab_settings(content)
     createTitle(content, "Settings", 18)
 
-    local checkBox = createSettingsCheckBox(content, "Display minimap button")
-    checkBox:SetScript("OnClick", function(self)
+    WHC_SETTINGS.minimap = createSettingsCheckBox(content, "Display minimap button")
+    WHC_SETTINGS.minimap:SetScript("OnClick", function(self)
+        WhcAddonSettings.minimapicon = math.abs(WhcAddonSettings.minimapicon - 1)
+        MapIcon:Hide()
         if (WhcAddonSettings.minimapicon == 1) then
-            WhcAddonSettings.minimapicon = 0
-
-            MapIcon:Hide()
-        else
-            WhcAddonSettings.minimapicon = 1
             MapIcon:Show()
         end
     end)
-    WHC_SETTINGS.minimap = checkBox
 
-    local checkBox1 = createSettingsCheckBox(content, "Display achievement button on inspect & character sheet")
-    checkBox1:SetScript("OnClick", function(self)
+    WHC_SETTINGS.achievementbtn = createSettingsCheckBox(content, "Display achievement button on inspect & character sheet")
+    WHC_SETTINGS.achievementbtn:SetScript("OnClick", function(self)
+        WhcAddonSettings.achievementbtn = math.abs(WhcAddonSettings.achievementbtn - 1)
+        if (ACHBtn) then
+            ACHBtn:Hide()
+        end
         if (WhcAddonSettings.achievementbtn == 1) then
-            WhcAddonSettings.achievementbtn = 0
-
-            if (ACHBtn) then
-                ACHBtn:Hide()
-            end
-        else
-            WhcAddonSettings.achievementbtn = 1
             if (ACHBtn) then
                 ACHBtn:Show()
             end
         end
     end)
-    WHC_SETTINGS.achievementbtn = checkBox1
 
-    local checkBox2 = createSettingsCheckBox(content, "Display Recent deaths frame")
-    checkBox2:SetScript("OnClick", function(self)
+    WHC_SETTINGS.recentDeathsBtn = createSettingsCheckBox(content, "Display Recent deaths frame")
+    WHC_SETTINGS.recentDeathsBtn:SetScript("OnClick", function(self)
+        WhcAddonSettings.recentDeaths = math.abs(WhcAddonSettings.recentDeaths - 1)
+        if (DeathLogFrame) then
+            DeathLogFrame:Hide()
+        end
         if (WhcAddonSettings.recentDeaths == 1) then
-            WhcAddonSettings.recentDeaths = 0
-
-            if (DeathLogFrame) then
-                DeathLogFrame:Hide()
-            end
-        else
-            WhcAddonSettings.recentDeaths = 1
             if (DeathLogFrame) then
                 DeathLogFrame:Show()
             end
         end
     end)
-    WHC_SETTINGS.recentDeathsBtn = checkBox2
 
     getNextOffsetY()
     createTitle(content, "Achievement Settings", 14)
 
-    local blockInvitesCheckbox = createSettingsCheckBox(content, "[Lone Wolf] Achievement: Block invites")
-    blockInvitesCheckbox:SetScript("OnClick", function(self)
-        if WhcAddonSettings.blockInvites == 1 then
-            WhcAddonSettings.blockInvites = 0
-        else
-            WhcAddonSettings.blockInvites = 1
-        end
+    WHC_SETTINGS.blockInvitesCheckbox = createSettingsCheckBox(content, "[Lone Wolf] Achievement: Block invites")
+    WHC_SETTINGS.blockInvitesCheckbox:SetScript("OnClick", function(self)
+        WhcAddonSettings.blockInvites = math.abs(WhcAddonSettings.blockInvites - 1)
         Whc_SetBlockInvites()
     end)
-    WHC_SETTINGS.blockInvitesCheckbox = blockInvitesCheckbox
 
-    local blockTradesCheckbox = createSettingsCheckBox(content, "[My Precious!] Achievement: Block trades")
-    blockTradesCheckbox:SetScript("OnClick", function(self)
-        if WhcAddonSettings.blockTrades == 1 then
-            WhcAddonSettings.blockTrades = 0
-        else
-            WhcAddonSettings.blockTrades = 1
-        end
+    WHC_SETTINGS.blockTradesCheckbox = createSettingsCheckBox(content, "[My Precious!] Achievement: Block trades")
+    WHC_SETTINGS.blockTradesCheckbox:SetScript("OnClick", function(self)
+        WhcAddonSettings.blockTrades = math.abs(WhcAddonSettings.blockTrades - 1)
         Whc_SetBlockTrades()
     end)
-    WHC_SETTINGS.blockTradesCheckbox = blockTradesCheckbox
 
     return content;
 end

--- a/Tabs/Shop.lua
+++ b/Tabs/Shop.lua
@@ -1,4 +1,4 @@
-function tab_shop(content)
+function WHC.Tab_Shop(content)
     local title = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     title:SetPoint("TOP", content, "TOP", 0, -10) -- Adjust y-offset based on logo size
     title:SetText("Shop")

--- a/Tabs/Support.lua
+++ b/Tabs/Support.lua
@@ -1,4 +1,4 @@
-function tab_support(content)
+function WHC.Tab_Support(content)
     local title = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     title:SetPoint("TOP", content, "TOP", 0, -10) -- Adjust y-offset based on logo size
     title:SetText("Support")
@@ -84,7 +84,7 @@ function tab_support(content)
         else
             SendChatMessage(msg);
         end
-            UIShowTabContent(0)
+            WHC.UIShowTabContent(0)
         end
     end)
 
@@ -104,7 +104,7 @@ function tab_support(content)
         else
             SendChatMessage(msg);
         end
-        UIShowTabContent(0)
+        WHC.UIShowTabContent(0)
 
     end)
     content.closeButton = closeButton;

--- a/UI.lua
+++ b/UI.lua
@@ -51,77 +51,23 @@ function UIShowTabContent(tabIndex, arg1)
                 SendChatMessage(msg);
             end
         elseif (tabIndex == "Settings") then
-            --    if (VARSLOADED) then
-            if (WhcAddonSettings.minimapicon == 1) then
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.minimap:SetChecked(true)
-                else
-                    WHC_SETTINGS.minimap:SetChecked(1)
+            local function checkedValue(value)
+                if RETAIL == 0 then
+                    return value
                 end
-            else
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.minimap:SetChecked(false)
-                else
-                    WHC_SETTINGS.minimap:SetChecked(0)
+
+                if value == 1 then
+                    return true
                 end
+
+                return false
             end
 
-            if (WhcAddonSettings.achievementbtn == 1) then
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.achievementbtn:SetChecked(true)
-                else
-                    WHC_SETTINGS.achievementbtn:SetChecked(1)
-                end
-            else
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.achievementbtn:SetChecked(false)
-                else
-                    WHC_SETTINGS.achievementbtn:SetChecked(0)
-                end
-            end
-
-            if (WhcAddonSettings.recentDeaths == 1) then
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.recentDeathsBtn:SetChecked(true)
-                else
-                    WHC_SETTINGS.recentDeathsBtn:SetChecked(1)
-                end
-            else
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.recentDeathsBtn:SetChecked(false)
-                else
-                    WHC_SETTINGS.recentDeathsBtn:SetChecked(0)
-                end
-            end
-
-            if (WhcAddonSettings.blockInvites == 1) then
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.blockInvitesCheckbox:SetChecked(true)
-                else
-                    WHC_SETTINGS.blockInvitesCheckbox:SetChecked(1)
-                end
-            else
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.blockInvitesCheckbox:SetChecked(false)
-                else
-                    WHC_SETTINGS.blockInvitesCheckbox:SetChecked(0)
-                end
-            end
-
-            if (WhcAddonSettings.blockTrades == 1) then
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.blockTradesCheckbox:SetChecked(true)
-                else
-                    WHC_SETTINGS.blockTradesCheckbox:SetChecked(1)
-                end
-            else
-                if (RETAIL == 1) then
-                    WHC_SETTINGS.blockTradesCheckbox:SetChecked(false)
-                else
-                    WHC_SETTINGS.blockTradesCheckbox:SetChecked(0)
-                end
-            end
-            -- end
+            WHC_SETTINGS.minimap:SetChecked(checkedValue(WhcAddonSettings.minimapicon))
+            WHC_SETTINGS.achievementbtn:SetChecked(checkedValue(WhcAddonSettings.achievementbtn))
+            WHC_SETTINGS.recentDeathsBtn:SetChecked(checkedValue(WhcAddonSettings.recentDeaths))
+            WHC_SETTINGS.blockInvitesCheckbox:SetChecked(checkedValue(WhcAddonSettings.blockInvites))
+            WHC_SETTINGS.blockTradesCheckbox:SetChecked(checkedValue(WhcAddonSettings.blockTrades))
         elseif (tabIndex == "General") then
             --
         end

--- a/UI.lua
+++ b/UI.lua
@@ -220,7 +220,7 @@ function WHC.InitializeUI()
         elseif value == "Shop" then
             content = WHC.Tab_Shop(content)
         elseif value == "Settings" then
-            content = tab_settings(content)
+            content = WHC.Tab_settings(content)
         else
             local text = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
             text:SetPoint("CENTER", content, "CENTER", 0, 0)

--- a/UI.lua
+++ b/UI.lua
@@ -5,6 +5,18 @@ UItab = {}
 tabKeys = { "General", "Achievements", "PVP", "Shop", "Support", "Settings" }
 
 
+function WHC.CheckedValue(value)
+    if RETAIL == 0 then
+        return value
+    end
+
+    if value == 1 then
+        return true
+    end
+
+    return false
+end
+
 -- Function to show the selected tab's content
 function WHC.UIShowTabContent(tabIndex, arg1)
     if tabIndex == 0 then
@@ -51,23 +63,11 @@ function WHC.UIShowTabContent(tabIndex, arg1)
                 SendChatMessage(msg);
             end
         elseif (tabIndex == "Settings") then
-            local function checkedValue(value)
-                if RETAIL == 0 then
-                    return value
-                end
-
-                if value == 1 then
-                    return true
-                end
-
-                return false
-            end
-
-            WHC_SETTINGS.minimap:SetChecked(checkedValue(WhcAddonSettings.minimapicon))
-            WHC_SETTINGS.achievementbtn:SetChecked(checkedValue(WhcAddonSettings.achievementbtn))
-            WHC_SETTINGS.recentDeathsBtn:SetChecked(checkedValue(WhcAddonSettings.recentDeaths))
-            WHC_SETTINGS.blockInvitesCheckbox:SetChecked(checkedValue(WhcAddonSettings.blockInvites))
-            WHC_SETTINGS.blockTradesCheckbox:SetChecked(checkedValue(WhcAddonSettings.blockTrades))
+            WHC_SETTINGS.minimap:SetChecked(WHC.CheckedValue(WhcAddonSettings.minimapicon))
+            WHC_SETTINGS.achievementbtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.achievementbtn))
+            WHC_SETTINGS.recentDeathsBtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.recentDeaths))
+            WHC_SETTINGS.blockInvitesCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockInvites))
+            WHC_SETTINGS.blockTradesCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockTrades))
         elseif (tabIndex == "General") then
             --
         end

--- a/UI.lua
+++ b/UI.lua
@@ -6,7 +6,7 @@ tabKeys = { "General", "Achievements", "PVP", "Shop", "Support", "Settings" }
 
 
 -- Function to show the selected tab's content
-function UIShowTabContent(tabIndex, arg1)
+function WHC.UIShowTabContent(tabIndex, arg1)
     if tabIndex == 0 then
         UIframe:Hide()
     else
@@ -97,9 +97,7 @@ function UIShowTabContent(tabIndex, arg1)
     end
 end
 
-function initUI()
-
-
+function WHC.InitializeUI()
     local frame = CreateFrame("Frame", "MyMultiTabFrame", UIParent, RETAIL_BACKDROP)
     UIframe = frame
     frame:SetWidth(500)
@@ -117,7 +115,7 @@ function initUI()
     frame:Hide()
 
 
-    closeFrame = CreateFrame("Button", "GMToolGUIClose", frame, "UIPanelCloseButton")
+    local closeFrame = CreateFrame("Button", "GMToolGUIClose", frame, "UIPanelCloseButton")
     closeFrame:SetWidth(30)
     closeFrame:SetHeight(30)
     closeFrame:SetPoint("TOPRIGHT", frame, "TOPRIGHT", 7, 6)
@@ -196,8 +194,8 @@ function initUI()
 
         local index = value
         tabHeader:SetScript("OnClick", function()
-            --DebugPrint("click " .. index)
-            UIShowTabContent(index)
+            --WHC.DebugPrint("click " .. index)
+            WHC.UIShowTabContent(index)
         end)
 
         UItabHeader[value] = tabHeader
@@ -212,15 +210,15 @@ function initUI()
 
 
         if value == "Achievements" then
-            content = tab_achievements(content)
+            content = WHC.Tab_Achievements(content)
         elseif value == "Support" then
-            content = tab_support(content)
+            content = WHC.Tab_Support(content)
         elseif value == "PVP" then
-            content = tab_PVP(content)
+            content = WHC.Tab_PVP(content)
         elseif value == "General" then
-            content = tab_general(content)
+            content = WHC.Tab_General(content)
         elseif value == "Shop" then
-            content = tab_shop(content)
+            content = WHC.Tab_Shop(content)
         elseif value == "Settings" then
             content = tab_settings(content)
         else
@@ -243,7 +241,7 @@ function initUI()
             UIframe:Hide()
         else
             UIframe:Show()
-            UIShowTabContent("General") -- Initialize with the first tab visible
+            WHC.UIShowTabContent("General") -- Initialize with the first tab visible
         end
     end
 end


### PR DESCRIPTION
**Bug fix**
The setting _Display Recent deaths frame_ was not correctly being unchecked if the user used the X-button on the death frame to close the window, which caused the checkbox to become out of sync with the frame

**Refactors**
* I was getting kind of insane by looking at all the if-else-stament that took up 10 lines each, when they really should just be a single line. So I took the liberty to refactor them for easy readability.
* It is generally a bad idea to leak anything to the global scope in LUA.  
Adding elements to the global scope can either overwrite something existing elements in another addon, making other addons break, or cause other addons to interact with elements of your addon, causing uninteded behaviour.
Recall how Gatherer sets `_G` globally and caused issues.
To avoid leaking to the global scope, I make a lot of functions and variables local, and I created a single global object for the Wow HC addon that all cross file functions are placed on. That way the function won't interfear with other addons

**Tested on both 1.12 and 1.14 without issues**
