### PR TITLE
Bugfix: Fixed play sound for 1.14

### DIFF
--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -78,6 +78,13 @@ local function playCheckedSound(checked)
     if checked == 1 then
         sound = "igMainMenuOptionCheckBoxOn"
     end
+
+    if RETAIL == 1 then
+        sound = 857
+        if checked == 1 then
+            sound = 856
+        end
+    end
     PlaySound(sound)
 end
 


### PR DESCRIPTION
1.14 uses soundIDs numbers instead of strings.