### PR TITLE
Refactor: Remove MapIcon and DeathLogFrame from the global scope

### DIFF
--- a/Init.lua
+++ b/Init.lua
@@ -18,6 +18,7 @@ end
 
 
 WHC = CreateFrame("Frame")
+WHC.Frames = {}
 WHC:RegisterEvent("ADDON_LOADED")
 WHC:SetScript("OnEvent", function(self, event, addonName)
     addonName = addonName or arg1
@@ -44,7 +45,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     end
 
     WHC.InitializeUI()
-
+    WHC.InitializeMinimapIcon()
 
     if (RETAIL == 1) then
         -- todo (low prio since ticket status block not displayed on retail)
@@ -84,9 +85,9 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WhcAddonSettings.blockNonSelfMadeItemsTooltip = WhcAddonSettings.blockNonSelfMadeItemsTooltip or 0
 
     if (WhcAddonSettings.minimapicon == 1) then
-        MapIcon:Show()
+        WHC.Frames.MapIcon:Show()
     else
-        MapIcon:Hide()
+        WHC.Frames.MapIcon:Hide()
     end
 
     if (WhcAddonSettings.recentDeaths == 1) then
@@ -108,39 +109,13 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
         WHC.UIShowTabContent("General")
     end
 
-    if WhcAddonSettings.blockInvites == 1 then
-        WHC.SetBlockInvites()
-    end
-
-    if WhcAddonSettings.blockTrades == 1 then
-        WHC.SetBlockTrades()
-    end
-
-    if WhcAddonSettings.blockAuctionSell == 1 then
-        WHC.SetBlockAuctionSell()
-    end
-
-    if WhcAddonSettings.blockAuctionBuy == 1 then
-        WHC.SetBlockAuctionBuy()
-    end
-
-    if WhcAddonSettings.blockRepair == 1 then
-        WHC.SetBlockRepair()
-    end
-
-    if WhcAddonSettings.blockTaxiService == 1 then
-        WHC.SetBlockTaxiService()
-    end
-
-    if WhcAddonSettings.blockMagicItems == 1 then
-        WHC.SetBlockEquipItems()
-    end
-
-    if WhcAddonSettings.blockArmorItems == 1 then
-        WHC.SetBlockEquipItems()
-    end
-
-    if WhcAddonSettings.blockNonSelfMadeItems == 1 then
-        WHC.SetBlockEquipItems()
-    end
+    WHC.SetBlockInvites()
+    WHC.SetBlockTrades()
+    WHC.SetBlockAuctionSell()
+    WHC.SetBlockAuctionBuy()
+    WHC.SetBlockRepair()
+    WHC.SetBlockTaxiService()
+    WHC.SetBlockEquipItems()
+    WHC.SetBlockEquipItems()
+    WHC.SetBlockEquipItems()
 end)

--- a/Init.lua
+++ b/Init.lua
@@ -16,7 +16,6 @@ else
 end
 
 WHC = CreateFrame("Frame")
-WHC.Frames = {}
 WHC:RegisterEvent("ADDON_LOADED")
 WHC:SetScript("OnEvent", function(self, event, addonName)
     addonName = addonName or arg1
@@ -24,6 +23,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
         return
     end
 
+    WHC.Frames = {}
     WHC.player = {
         name = UnitName("player"),
     }

--- a/Init.lua
+++ b/Init.lua
@@ -15,8 +15,6 @@ else
     RETAIL_BACKDROP = nil
 end
 
-
-
 WHC = CreateFrame("Frame")
 WHC.Frames = {}
 WHC:RegisterEvent("ADDON_LOADED")
@@ -46,6 +44,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
 
     WHC.InitializeUI()
     WHC.InitializeMinimapIcon()
+    WHC.InitializeDeathLogFrame()
 
     if (RETAIL == 1) then
         -- todo (low prio since ticket status block not displayed on retail)
@@ -91,9 +90,9 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     end
 
     if (WhcAddonSettings.recentDeaths == 1) then
-        DeathLogFrame:Show()
+        WHC.Frames.DeathLogFrame:Show()
     else
-        DeathLogFrame:Hide()
+        WHC.Frames.DeathLogFrame:Hide()
     end
 
     local msg = ".whc version " .. GetAddOnMetadata("WOW_HC", "Version")

--- a/MinimapButton.lua
+++ b/MinimapButton.lua
@@ -1,57 +1,54 @@
-local minimapIcon = CreateFrame('Button', "minimapIcon", Minimap)
+function WHC.InitializeMinimapIcon()
+    local minimapIcon = CreateFrame('Button', "minimapIcon", Minimap)
 
-minimapIcon:RegisterForDrag('LeftButton')
-minimapIcon:RegisterForClicks('LeftButtonUp', 'RightButtonUp')
-minimapIcon:SetMovable(true)
-minimapIcon:EnableMouse(true)
-minimapIcon:SetScript("OnEnter", function()
-    GameTooltip:SetOwner(minimapIcon, ANCHOR_BOTTOMLEFT)
-    GameTooltip:AddLine("WOW-HC", 0.933, 0.765, 0)
-    GameTooltip:AddDoubleLine("Click", "Open", 1, 1, 1, 1, 1, 1)
-    GameTooltip:AddDoubleLine("Shift + Click", "Move", 1, 1, 1, 1, 1, 1)
-    GameTooltip:Show()
-end)
-minimapIcon:SetClampedToScreen(true)
+    minimapIcon:RegisterForDrag('LeftButton')
+    minimapIcon:RegisterForClicks('LeftButtonUp', 'RightButtonUp')
+    minimapIcon:SetMovable(true)
+    minimapIcon:EnableMouse(true)
+    minimapIcon:SetScript("OnEnter", function()
+        GameTooltip:SetOwner(minimapIcon, ANCHOR_BOTTOMLEFT)
+        GameTooltip:AddLine("WOW-HC", 0.933, 0.765, 0)
+        GameTooltip:AddDoubleLine("Click", "Open", 1, 1, 1, 1, 1, 1)
+        GameTooltip:AddDoubleLine("Shift + Click", "Move", 1, 1, 1, 1, 1, 1)
+        GameTooltip:Show()
+    end)
+    minimapIcon:SetClampedToScreen(true)
 
+    minimapIcon:SetScript("OnClick", function()
+        if (UIframe:IsVisible()) then
+            WHC.UIShowTabContent(0)
+        else
+            WHC.UIShowTabContent("General")
+        end
+    end)
 
-minimapIcon:SetScript("OnClick", function()
-    if (UIframe:IsVisible()) then
-        WHC.UIShowTabContent(0)
-    else
-        WHC.UIShowTabContent("General")
-    end
-end)
+    minimapIcon:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+    minimapIcon:SetScript("OnDragStart", function()
+        if IsShiftKeyDown() then
+            minimapIcon:StartMoving()
+        end
+    end)
+    minimapIcon:SetScript("OnDragStop", function()
+        minimapIcon:StopMovingOrSizing()
+        local point, relativeTo, relativePoint, xOffset, yOffset = minimapIcon:GetPoint()
+        WhcAddonSettings.minimapX = xOffset;
+        WhcAddonSettings.minimapX = yOffset;
+    end)
 
+    minimapIcon:SetFrameLevel(9)
+    minimapIcon:SetFrameStrata('HIGH')
+    minimapIcon:SetWidth(30)
+    minimapIcon:SetHeight(30)
+    minimapIcon:SetNormalTexture("Interface\\AddOns\\WOW_HC\\Images\\wow-hardcore-logo-round")
+    minimapIcon:SetPoint("TOPLEFT", Minimap, "TOPLEFT", 0, 0)
 
+    local border = minimapIcon:CreateTexture(nil, "OVERLAY")
+    border:SetTexture("Interface\\Minimap\\MiniMap-TrackingBorder")
+    border:SetPoint("CENTER", minimapIcon, "CENTER", 14, -15)
+    border:SetWidth(66)
+    border:SetHeight(66)
 
-minimapIcon:SetScript("OnLeave", function()
-    GameTooltip:Hide()
-end)
-minimapIcon:SetScript("OnDragStart", function()
-    if IsShiftKeyDown() then
-        minimapIcon:StartMoving()
-    end
-end)
-minimapIcon:SetScript("OnDragStop", function()
-    minimapIcon:StopMovingOrSizing()
-    local point, relativeTo, relativePoint, xOffset, yOffset = minimapIcon:GetPoint()
-    WhcAddonSettings.minimapX = xOffset;
-    WhcAddonSettings.minimapX = yOffset;
-end)
-
-minimapIcon:SetFrameLevel(9)
-minimapIcon:SetFrameStrata('HIGH')
-minimapIcon:SetWidth(30)
-minimapIcon:SetHeight(30)
-minimapIcon:SetNormalTexture("Interface\\AddOns\\WOW_HC\\Images\\wow-hardcore-logo-round")
-minimapIcon:SetPoint("TOPLEFT", Minimap, "TOPLEFT", 0, 0)
-
-
-local border = minimapIcon:CreateTexture(nil, "OVERLAY")
-border:SetTexture("Interface\\Minimap\\MiniMap-TrackingBorder")
-border:SetPoint("CENTER", minimapIcon, "CENTER", 14, -15)
-border:SetWidth(66)
-border:SetHeight(66)
-
-
-MapIcon = minimapIcon
+    WHC.Frames.MapIcon = minimapIcon
+end

--- a/RecentDeaths.lua
+++ b/RecentDeaths.lua
@@ -1,92 +1,89 @@
-DeathLogFrame = CreateFrame("Frame", "MyAddonFrame", UIParent, RETAIL_BACKDROP)
-DeathLogFrame:SetWidth(400)
-DeathLogFrame:SetHeight(300)
-DeathLogFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
-DeathLogFrame:SetMovable(true)
-DeathLogFrame:EnableMouse(true)
-DeathLogFrame:SetScript("OnMouseDown", function()
-    DeathLogFrame:StartMoving()
-end)
+function WHC.InitializeDeathLogFrame()
+    WHC.Frames.DeathLogFrame = CreateFrame("Frame", "MyAddonFrame", UIParent, RETAIL_BACKDROP)
+    WHC.Frames.DeathLogFrame:SetWidth(400)
+    WHC.Frames.DeathLogFrame:SetHeight(300)
+    WHC.Frames.DeathLogFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+    WHC.Frames.DeathLogFrame:SetMovable(true)
+    WHC.Frames.DeathLogFrame:EnableMouse(true)
+    WHC.Frames.DeathLogFrame:SetScript("OnMouseDown", function()
+        WHC.Frames.DeathLogFrame:StartMoving()
+    end)
 
-DeathLogFrame:SetScript("OnMouseUp", function()
-    DeathLogFrame:StopMovingOrSizing()
-end)
+    WHC.Frames.DeathLogFrame:SetScript("OnMouseUp", function()
+        WHC.Frames.DeathLogFrame:StopMovingOrSizing()
+    end)
 
-DeathLogFrame:SetBackdrop({
-    bgFile = "Interface/Tooltips/UI-Tooltip-Background",
-    edgeFile = "Interface/Tooltips/UI-Tooltip-Border",
-    tile = true,
-    tileSize = 16,
-    edgeSize = 16,
-    insets = { left = 4, right = 4, top = 4, bottom = 4 }
-})
-DeathLogFrame:SetBackdropColor(0, 0, 0, 0.8)
-DeathLogFrame:SetBackdropBorderColor(.5, .5, .5, 1)
+    WHC.Frames.DeathLogFrame:SetBackdrop({
+        bgFile = "Interface/Tooltips/UI-Tooltip-Background",
+        edgeFile = "Interface/Tooltips/UI-Tooltip-Border",
+        tile = true,
+        tileSize = 16,
+        edgeSize = 16,
+        insets = { left = 4, right = 4, top = 4, bottom = 4 }
+    })
+    WHC.Frames.DeathLogFrame:SetBackdropColor(0, 0, 0, 0.8)
+    WHC.Frames.DeathLogFrame:SetBackdropBorderColor(.5, .5, .5, 1)
 
-local title = DeathLogFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-title:SetPoint("TOP", DeathLogFrame, "TOP", 0, -10)
-title:SetText("Recent Deaths")
-title:SetTextColor(0.933, 0.765, 0)
+    local title = WHC.Frames.DeathLogFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    title:SetPoint("TOP", WHC.Frames.DeathLogFrame, "TOP", 0, -10)
+    title:SetText("Recent Deaths")
+    title:SetTextColor(0.933, 0.765, 0)
 
+    local scrollFrame = CreateFrame("ScrollFrame", "MyAddonScrollFrame", WHC.Frames.DeathLogFrame, "UIPanelScrollFrameTemplate")
+    scrollFrame:SetPoint("TOPLEFT", WHC.Frames.DeathLogFrame, "TOPLEFT", 10, -30)
+    scrollFrame:SetPoint("BOTTOMRIGHT", WHC.Frames.DeathLogFrame, "BOTTOMRIGHT", -30, 10)
 
-local scrollFrame = CreateFrame("ScrollFrame", "MyAddonScrollFrame", DeathLogFrame, "UIPanelScrollFrameTemplate")
-scrollFrame:SetPoint("TOPLEFT", DeathLogFrame, "TOPLEFT", 10, -30)
-scrollFrame:SetPoint("BOTTOMRIGHT", DeathLogFrame, "BOTTOMRIGHT", -30, 10)
+    local content = CreateFrame("Frame", "MyAddonScrollContent", scrollFrame)
+    content:SetWidth(360)
+    content:SetHeight(0)
+    scrollFrame:SetScrollChild(content)
+    WHC.DeathLogFrame.content = content
 
+    local closeButton = CreateFrame("Button", nil, WHC.Frames.DeathLogFrame, "UIPanelCloseButton")
+    closeButton:SetPoint("TOPRIGHT", WHC.Frames.DeathLogFrame, "TOPRIGHT", 2, 1)
+    closeButton:SetWidth(36)
+    closeButton:SetHeight(36)
+    closeButton:SetText("Close")
+    closeButton:SetScript("OnClick", function()
+        WhcAddonSettings.recentDeaths = 0
+        WHC_SETTINGS.recentDeathsBtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.recentDeaths))
+        WHC.Frames.DeathLogFrame:Hide()
+    end)
 
-local content = CreateFrame("Frame", "MyAddonScrollContent", scrollFrame)
-content:SetWidth(360)
-content:SetHeight(0)
-scrollFrame:SetScrollChild(content)
+    local resizeButton = CreateFrame("Button", nil, WHC.Frames.DeathLogFrame)
+    resizeButton:SetPoint("BOTTOMRIGHT", WHC.Frames.DeathLogFrame, "BOTTOMRIGHT", 2, -3)
+    resizeButton:SetWidth(16)
+    resizeButton:SetHeight(16)
 
-local closeButton = CreateFrame("Button", nil, DeathLogFrame, "UIPanelCloseButton")
-closeButton:SetPoint("TOPRIGHT", DeathLogFrame, "TOPRIGHT", 2, 1)
-closeButton:SetWidth(36)
-closeButton:SetHeight(36)
-closeButton:SetText("Close")
-closeButton:SetScript("OnClick", function()
-    WhcAddonSettings.recentDeaths = 0
-    WHC_SETTINGS.recentDeathsBtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.recentDeaths))
-    DeathLogFrame:Hide()
-end)
+    local function SetRotation(texture, angle)
+        local cos, sin = math.cos(angle), math.sin(angle)
+        texture:SetTexCoord(
+                0.5 - 0.5 * cos + 0.5 * sin, 0.5 - 0.5 * sin - 0.5 * cos,
+                0.5 + 0.5 * cos + 0.5 * sin, 0.5 + 0.5 * sin - 0.5 * cos,
+                0.5 - 0.5 * cos - 0.5 * sin, 0.5 - 0.5 * sin + 0.5 * cos,
+                0.5 + 0.5 * cos - 0.5 * sin, 0.5 + 0.5 * sin + 0.5 * cos
+        )
+    end
 
+    local resizeTexture = resizeButton:CreateTexture(nil, "BACKGROUND")
+    resizeTexture:SetTexture("Interface\\ChatFrame\\ChatFrameExpandArrow")
+    resizeTexture:SetWidth(9)
+    resizeTexture:SetHeight(9)
+    resizeTexture:SetPoint("CENTER", resizeButton, "CENTER", 0, 0)
+    SetRotation(resizeTexture, math.rad(80))
 
-local resizeButton = CreateFrame("Button", nil, DeathLogFrame)
-resizeButton:SetPoint("BOTTOMRIGHT", DeathLogFrame, "BOTTOMRIGHT", 2, -3)
-resizeButton:SetWidth(16)
-resizeButton:SetHeight(16)
+    WHC.Frames.DeathLogFrame:SetResizable(true)
+    WHC.Frames.DeathLogFrame:SetMinResize(10, 10)
+    WHC.Frames.DeathLogFrame:SetMaxResize(800, 600)
 
-local function SetRotation(texture, angle)
-    local cos, sin = math.cos(angle), math.sin(angle)
-    texture:SetTexCoord(
-            0.5 - 0.5 * cos + 0.5 * sin, 0.5 - 0.5 * sin - 0.5 * cos,
-            0.5 + 0.5 * cos + 0.5 * sin, 0.5 + 0.5 * sin - 0.5 * cos,
-            0.5 - 0.5 * cos - 0.5 * sin, 0.5 - 0.5 * sin + 0.5 * cos,
-            0.5 + 0.5 * cos - 0.5 * sin, 0.5 + 0.5 * sin + 0.5 * cos
-    )
+    resizeButton:EnableMouse(true)
+    resizeButton:SetScript("OnMouseDown", function(self, button)
+        WHC.Frames.DeathLogFrame:StartSizing("BOTTOMRIGHT")
+    end)
+    resizeButton:SetScript("OnMouseUp", function(self, button)
+        WHC.Frames.DeathLogFrame:StopMovingOrSizing()
+    end)
 end
-
-local resizeTexture = resizeButton:CreateTexture(nil, "BACKGROUND")
-resizeTexture:SetTexture("Interface\\ChatFrame\\ChatFrameExpandArrow")
-resizeTexture:SetWidth(9)
-resizeTexture:SetHeight(9)
-resizeTexture:SetPoint("CENTER", resizeButton, "CENTER", 0, 0)
-SetRotation(resizeTexture, math.rad(80))
-
-
-
-DeathLogFrame:SetResizable(true)
-DeathLogFrame:SetMinResize(10, 10)
-DeathLogFrame:SetMaxResize(800, 600)
-
-resizeButton:EnableMouse(true)
-resizeButton:SetScript("OnMouseDown", function(self, button)
-    DeathLogFrame:StartSizing("BOTTOMRIGHT")
-end)
-resizeButton:SetScript("OnMouseUp", function(self, button)
-    DeathLogFrame:StopMovingOrSizing()
-end)
-
 
 local deathMessages = {}
 local fontHeight = 14
@@ -113,8 +110,8 @@ function WHC.LogDeathMessage(msg)
 
         local countRows = 0
         for i, message in ipairs(deathMessages) do
-            local rowString = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-            rowString:SetPoint("TOPLEFT", content, "TOPLEFT", 0, -fontHeight * (i - 1))
+            local rowString = WHC.DeathLogFrame.content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+            rowString:SetPoint("TOPLEFT", WHC.DeathLogFrame.content, "TOPLEFT", 0, -fontHeight * (i - 1))
             rowString:SetFont("Fonts\\FRIZQT__.TTF", fontHeight - 2, "OUTLINE")
             rowString:SetText(message)
 
@@ -123,6 +120,6 @@ function WHC.LogDeathMessage(msg)
             countRows = countRows + 1
         end
 
-        content:SetHeight(fontHeight * countRows)
+        WHC.DeathLogFrame.content:SetHeight(fontHeight * countRows)
     end
 end

--- a/RecentDeaths.lua
+++ b/RecentDeaths.lua
@@ -1,19 +1,19 @@
 function WHC.InitializeDeathLogFrame()
-    WHC.Frames.DeathLogFrame = CreateFrame("Frame", "MyAddonFrame", UIParent, RETAIL_BACKDROP)
-    WHC.Frames.DeathLogFrame:SetWidth(400)
-    WHC.Frames.DeathLogFrame:SetHeight(300)
-    WHC.Frames.DeathLogFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
-    WHC.Frames.DeathLogFrame:SetMovable(true)
-    WHC.Frames.DeathLogFrame:EnableMouse(true)
-    WHC.Frames.DeathLogFrame:SetScript("OnMouseDown", function()
-        WHC.Frames.DeathLogFrame:StartMoving()
+    local deathLogFrame = CreateFrame("Frame", "MyAddonFrame", UIParent, RETAIL_BACKDROP)
+    deathLogFrame:SetWidth(400)
+    deathLogFrame:SetHeight(300)
+    deathLogFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+    deathLogFrame:SetMovable(true)
+    deathLogFrame:EnableMouse(true)
+    deathLogFrame:SetScript("OnMouseDown", function()
+        deathLogFrame:StartMoving()
     end)
 
-    WHC.Frames.DeathLogFrame:SetScript("OnMouseUp", function()
-        WHC.Frames.DeathLogFrame:StopMovingOrSizing()
+    deathLogFrame:SetScript("OnMouseUp", function()
+        deathLogFrame:StopMovingOrSizing()
     end)
 
-    WHC.Frames.DeathLogFrame:SetBackdrop({
+    deathLogFrame:SetBackdrop({
         bgFile = "Interface/Tooltips/UI-Tooltip-Background",
         edgeFile = "Interface/Tooltips/UI-Tooltip-Border",
         tile = true,
@@ -21,37 +21,37 @@ function WHC.InitializeDeathLogFrame()
         edgeSize = 16,
         insets = { left = 4, right = 4, top = 4, bottom = 4 }
     })
-    WHC.Frames.DeathLogFrame:SetBackdropColor(0, 0, 0, 0.8)
-    WHC.Frames.DeathLogFrame:SetBackdropBorderColor(.5, .5, .5, 1)
+    deathLogFrame:SetBackdropColor(0, 0, 0, 0.8)
+    deathLogFrame:SetBackdropBorderColor(.5, .5, .5, 1)
 
-    local title = WHC.Frames.DeathLogFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-    title:SetPoint("TOP", WHC.Frames.DeathLogFrame, "TOP", 0, -10)
+    local title = deathLogFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    title:SetPoint("TOP", deathLogFrame, "TOP", 0, -10)
     title:SetText("Recent Deaths")
     title:SetTextColor(0.933, 0.765, 0)
 
-    local scrollFrame = CreateFrame("ScrollFrame", "MyAddonScrollFrame", WHC.Frames.DeathLogFrame, "UIPanelScrollFrameTemplate")
-    scrollFrame:SetPoint("TOPLEFT", WHC.Frames.DeathLogFrame, "TOPLEFT", 10, -30)
-    scrollFrame:SetPoint("BOTTOMRIGHT", WHC.Frames.DeathLogFrame, "BOTTOMRIGHT", -30, 10)
+    local scrollFrame = CreateFrame("ScrollFrame", "MyAddonScrollFrame", deathLogFrame, "UIPanelScrollFrameTemplate")
+    scrollFrame:SetPoint("TOPLEFT", deathLogFrame, "TOPLEFT", 10, -30)
+    scrollFrame:SetPoint("BOTTOMRIGHT", deathLogFrame, "BOTTOMRIGHT", -30, 10)
 
     local content = CreateFrame("Frame", "MyAddonScrollContent", scrollFrame)
     content:SetWidth(360)
     content:SetHeight(0)
     scrollFrame:SetScrollChild(content)
-    WHC.DeathLogFrame.content = content
+    deathLogFrame.content = content
 
-    local closeButton = CreateFrame("Button", nil, WHC.Frames.DeathLogFrame, "UIPanelCloseButton")
-    closeButton:SetPoint("TOPRIGHT", WHC.Frames.DeathLogFrame, "TOPRIGHT", 2, 1)
+    local closeButton = CreateFrame("Button", nil, deathLogFrame, "UIPanelCloseButton")
+    closeButton:SetPoint("TOPRIGHT", deathLogFrame, "TOPRIGHT", 2, 1)
     closeButton:SetWidth(36)
     closeButton:SetHeight(36)
     closeButton:SetText("Close")
     closeButton:SetScript("OnClick", function()
         WhcAddonSettings.recentDeaths = 0
         WHC_SETTINGS.recentDeathsBtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.recentDeaths))
-        WHC.Frames.DeathLogFrame:Hide()
+        deathLogFrame:Hide()
     end)
 
-    local resizeButton = CreateFrame("Button", nil, WHC.Frames.DeathLogFrame)
-    resizeButton:SetPoint("BOTTOMRIGHT", WHC.Frames.DeathLogFrame, "BOTTOMRIGHT", 2, -3)
+    local resizeButton = CreateFrame("Button", nil, deathLogFrame)
+    resizeButton:SetPoint("BOTTOMRIGHT", deathLogFrame, "BOTTOMRIGHT", 2, -3)
     resizeButton:SetWidth(16)
     resizeButton:SetHeight(16)
 
@@ -72,17 +72,19 @@ function WHC.InitializeDeathLogFrame()
     resizeTexture:SetPoint("CENTER", resizeButton, "CENTER", 0, 0)
     SetRotation(resizeTexture, math.rad(80))
 
-    WHC.Frames.DeathLogFrame:SetResizable(true)
-    WHC.Frames.DeathLogFrame:SetMinResize(10, 10)
-    WHC.Frames.DeathLogFrame:SetMaxResize(800, 600)
+    deathLogFrame:SetResizable(true)
+    deathLogFrame:SetMinResize(10, 10)
+    deathLogFrame:SetMaxResize(800, 600)
 
     resizeButton:EnableMouse(true)
     resizeButton:SetScript("OnMouseDown", function(self, button)
-        WHC.Frames.DeathLogFrame:StartSizing("BOTTOMRIGHT")
+        deathLogFrame:StartSizing("BOTTOMRIGHT")
     end)
     resizeButton:SetScript("OnMouseUp", function(self, button)
-        WHC.Frames.DeathLogFrame:StopMovingOrSizing()
+        deathLogFrame:StopMovingOrSizing()
     end)
+
+    WHC.Frames.DeathLogFrame = deathLogFrame
 end
 
 local deathMessages = {}
@@ -110,8 +112,8 @@ function WHC.LogDeathMessage(msg)
 
         local countRows = 0
         for i, message in ipairs(deathMessages) do
-            local rowString = WHC.DeathLogFrame.content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-            rowString:SetPoint("TOPLEFT", WHC.DeathLogFrame.content, "TOPLEFT", 0, -fontHeight * (i - 1))
+            local rowString = WHC.Frames.DeathLogFrame.content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+            rowString:SetPoint("TOPLEFT", WHC.Frames.DeathLogFrame.content, "TOPLEFT", 0, -fontHeight * (i - 1))
             rowString:SetFont("Fonts\\FRIZQT__.TTF", fontHeight - 2, "OUTLINE")
             rowString:SetText(message)
 
@@ -120,6 +122,6 @@ function WHC.LogDeathMessage(msg)
             countRows = countRows + 1
         end
 
-        WHC.DeathLogFrame.content:SetHeight(fontHeight * countRows)
+        WHC.Frames.DeathLogFrame.content:SetHeight(fontHeight * countRows)
     end
 end

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -128,13 +128,9 @@ function WHC.Tab_Settings(content)
     WHC_SETTINGS.recentDeathsBtn:SetScript("OnClick", function(self)
         WhcAddonSettings.recentDeaths = math.abs(WhcAddonSettings.recentDeaths - 1)
         playCheckedSound(WhcAddonSettings.recentDeaths)
-        if (DeathLogFrame) then
-            DeathLogFrame:Hide()
-        end
+        WHC.Frames.DeathLogFrame:Hide()
         if (WhcAddonSettings.recentDeaths == 1) then
-            if (DeathLogFrame) then
-                DeathLogFrame:Show()
-            end
+            WHC.Frames.DeathLogFrame:Show()
         end
     end)
 

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -81,7 +81,7 @@ local function playCheckedSound(checked)
     PlaySound(sound)
 end
 
-function WHC.Tab_settings(content)
+function WHC.Tab_Settings(content)
     local title = createTitle(content, "Settings", 18)
 
     content.desc1 = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
@@ -104,9 +104,9 @@ function WHC.Tab_settings(content)
     WHC_SETTINGS.minimap:SetScript("OnClick", function(self)
         WhcAddonSettings.minimapicon = math.abs(WhcAddonSettings.minimapicon - 1)
         playCheckedSound(WhcAddonSettings.minimapicon)
-        MapIcon:Hide()
+        WHC.Frames.MapIcon:Hide()
         if (WhcAddonSettings.minimapicon == 1) then
-            MapIcon:Show()
+            WHC.Frames.MapIcon:Show()
         end
     end)
 

--- a/UI.lua
+++ b/UI.lua
@@ -227,7 +227,7 @@ function WHC.InitializeUI()
         elseif value == "Shop" then
             content = WHC.Tab_Shop(content)
         elseif value == "Settings" then
-            content = WHC.Tab_settings(content)
+            content = WHC.Tab_Settings(content)
         else
             local text = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
             text:SetPoint("CENTER", content, "CENTER", 0, 0)


### PR DESCRIPTION
As previously discussed, variables should not be added to the global scope. Therefore, I have moved the following frames to the local scope of the addon:
- Minimap icon
- DeathLogFrame