### PR TITLE
Bugfix: Correctly initializes the tooltip checkboxes

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -73,8 +73,11 @@ function WHC.UIShowTabContent(tabIndex, arg1)
             WHC_SETTINGS.blockRepairCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockRepair))
             WHC_SETTINGS.blockTaxiServiceCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockTaxiService))
             WHC_SETTINGS.blockMagicItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockMagicItems))
+            WHC_SETTINGS.blockMagicItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockMagicItemsTooltip))
             WHC_SETTINGS.blockArmorItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockArmorItems))
+            WHC_SETTINGS.blockArmorItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockArmorItemsTooltip))
             WHC_SETTINGS.blockNonSelfMadeItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockNonSelfMadeItems))
+            WHC_SETTINGS.blockNonSelfMadeItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAddonSettings.blockNonSelfMadeItemsTooltip))
         elseif (tabIndex == "General") then
             --
         end


### PR DESCRIPTION
The tooltip checkboxes were not being correctly initialized which could cause the checkbox value and the backend value to get desynced.