### PR TITLE
Bugfix: Block riding skill on initialize

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -742,14 +742,18 @@ marathonRunnerEventListener:SetScript("OnEvent", function(self, eventName, addon
     end
 end)
 
+local function getQuestID()
+    if GetQuestID then -- 1.14 feature
+        return GetQuestID()
+    end
+
+    return 0
+end
+
 if QuestFrameAcceptButton then
     hooksecurefunc(QuestFrameAcceptButton, "Enable", function()
         if WhcAchievementSettings.blockRidingSkill == 1 then
-            local questID = 0
-            if GetQuestID then
-                questID = GetQuestID() -- 1.14 feature
-            end
-
+            local questID = getQuestID()
             local questName = GetTitleText()
             if marathonRunnerBlockedQuests[questID] or marathonRunnerBlockedQuests[questName] then
                 QuestFrameAcceptButton:Disable()
@@ -761,11 +765,7 @@ end
 if QuestFrameCompleteQuestButton then
     hooksecurefunc(QuestFrameCompleteQuestButton, "Enable", function()
         if WhcAchievementSettings.blockRidingSkill == 1 then
-            local questID = 0
-            if GetQuestID then
-                questID = GetQuestID() -- 1.14 feature
-            end
-
+            local questID = getQuestID()
             local questName = GetTitleText()
             if marathonRunnerBlockedQuests[questID] or marathonRunnerBlockedQuests[questName] then
                 QuestFrameCompleteQuestButton:Disable()
@@ -793,8 +793,9 @@ function WHC.SetBlockRidingSkill()
         end
 
         AcceptQuest = function()
+            local questID = getQuestID
             local questName = GetTitleText()
-            if marathonRunnerBlockedQuests[questName] then
+            if marathonRunnerBlockedQuests[questID] or marathonRunnerBlockedQuests[questName] then
                 return printAchievementInfo(marathonRunnerLink, format("Accepting [%s] is blocked as the reward includes riding skill.", questName))
             end
 
@@ -802,8 +803,9 @@ function WHC.SetBlockRidingSkill()
         end
         
         GetQuestReward = function(itemChoice)
+            local questID = getQuestID()
             local questName = GetTitleText()
-            if marathonRunnerBlockedQuests[questName] then
+            if marathonRunnerBlockedQuests[questID] or marathonRunnerBlockedQuests[questName] then
                 return printAchievementInfo(marathonRunnerLink, format("Completing [%s] is blocked as the reward includes riding skill.", questName))
             end
 

--- a/Init.lua
+++ b/Init.lua
@@ -120,6 +120,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WHC.SetBlockRepair()
     WHC.SetBlockTaxiService()
     WHC.SetBlockMailItems()
+    WHC.SetBlockRidingSkill()
     if RETAIL == 0 then
         WHC.SetBlockEquipItems()
     end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 ## Changelog for next update
+- Settings checkbox for Marathon Runner achievement, blocking learning riding skill
 
 
 ## Future versions:


### PR DESCRIPTION
## Bugfix

- Forgot to call `SetBlockRiding()` so if a player relogged, then the buttons would not be correctly blocked.
- Used QuestID on 1.14 to check if buttons should be disabled.
- Updated changelog

## Refactor

Made a local function to get questID to avoid having to copy and paste the same if check 4 times.