### PR TITLE
New Feature: Help yourself achievement

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -817,7 +817,100 @@ end
 --region ====== Help Yourself ======
 local helpYourselfLink = WHC.Achievements.HELP_YOURSELF.itemLink
 
-function WHC.SetBlockQuests()
+local helpYourselfAllowedCategories = {
+    ["Warrior"] = true, -- English
+    ["Krieger"] = true, -- German
+    ["Guerrero"] = true, -- Spanish
+    ["Guerrero"] = true, -- Spanish (Mexico)
+    ["Guerrier"] = true, -- French
+    ["Guerriero"] = true, -- Italian
+    ["Guerreiro"] = true, -- Portuguese
+    ["Воин"] = true, -- Russian
+    ["전사"] = true, -- Korean
+    ["战士"] = true, -- Chinese (Simplified)
+    ["戰士"] = true, -- Chinese (Traditional)
 
+    ["Paladin"] = true, -- English
+    ["Paladin"] = true, -- German
+    ["Paladín"] = true, -- Spanish
+    ["Paladín"] = true, -- Spanish (Mexico)
+    ["Paladin"] = true, -- French
+    ["Paladino"] = true, -- Italian
+    ["Paladino"] = true, -- Portuguese
+    ["Паладин"] = true, -- Russian
+    ["성기사"] = true, -- Korean
+    ["圣骑士"] = true, -- Chinese (Simplified)
+    ["聖騎士"] = true, -- Chinese (Traditional)
+
+    ["Hunter"] = true, -- English
+    ["Jäger"] = true, -- German
+    ["Cazador"] = true, -- Spanish
+    ["Cazador"] = true, -- Spanish (Mexico)
+    ["Chasseur"] = true, -- French
+    ["Cacciatore"] = true, -- Italian
+    ["Caçador"] = true, -- Portuguese
+    ["Охотник"] = true, -- Russian
+    ["사냥꾼"] = true, -- Korean
+    ["猎人"] = true, -- Chinese (Simplified)
+    ["獵人"] = true, -- Chinese (Traditional)
+
+    ["Rogue"] = true, -- English
+    ["Schurke"] = true, -- German
+    ["Pícaro"] = true, -- Spanish
+    ["Pícaro"] = true, -- Spanish (Mexico)
+    ["Voleur"] = true, -- French
+    ["Ladro"] = true, -- Italian
+    ["Ladino"] = true, -- Portuguese
+    ["Разбойник"] = true, -- Russian
+    ["도적"] = true, -- Korean
+    ["潜行者"] = true, -- Chinese (Simplified)
+    ["盜賊"] = true, -- Chinese (Traditional)
+
+    ["Priest"] = true, -- English
+    ["Priester"] = true, -- German
+    ["Sacerdote"] = true, -- Spanish
+    ["Sacerdote"] = true, -- Spanish (Mexico)
+    ["Prêtre"] = true, -- French
+    ["Sacerdote"] = true, -- Italian
+    ["Sacerdote"] = true, -- Portuguese
+    ["Жрец"] = true, -- Russian
+    ["사제"] = true, -- Korean
+    ["牧师"] = true, -- Chinese (Simplified)
+    ["牧師"] = true, -- Chinese (Traditional)
+}
+
+local function getQuestLogTitle(questLogIndex)
+    local questTitle, _, _, isHeader, isCollapsed = GetQuestLogTitle(questLogIndex);
+    if RETAIL == 1 then
+        questTitle, _, _, _, isHeader, isCollapsed = GetQuestLogTitle(questLogIndex);
+    end
+
+    return questTitle, isHeader, isCollapsed
+end
+
+local blockQuestsEventListener = CreateFrame("Frame")
+blockQuestsEventListener:SetScript("OnEvent", function()
+    local headerName = ""
+    for questLogIndex = 1, GetNumQuestLogEntries() do
+        local questTitle, isHeader, isCollapsed = getQuestLogTitle(questLogIndex)
+        if isHeader then
+            headerName = questTitle
+        end
+
+        if not isHeader then
+
+        end
+    end
+end)
+function WHC.SetBlockQuests()
+    local event = "QUEST_LOG_UPDATE"
+    if RETAIL == 1 then
+        event = "QUEST_ACCEPTED" -- test if this exist on 1.12 even though Chat GPT says it doesn't
+    end
+    blockQuestsEventListener:UnregisterEvent(event)
+
+    if WhcAchievementSettings.blockQuests == 1 then
+        blockQuestsEventListener:RegisterEvent(event)
+    end
 end
 --endregion

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -817,115 +817,29 @@ end
 --region ====== Help Yourself ======
 local helpYourselfLink = WHC.Achievements.HELP_YOURSELF.itemLink
 
-local helpYourselfAllowedCategories = {
-    ["Warrior"] = true, -- English
-    ["Krieger"] = true, -- German
-    ["Guerrero"] = true, -- Spanish
-    ["Guerrero"] = true, -- Spanish (Mexico)
-    ["Guerrier"] = true, -- French
-    ["Guerriero"] = true, -- Italian
-    ["Guerreiro"] = true, -- Portuguese
-    ["Воин"] = true, -- Russian
-    ["전사"] = true, -- Korean
-    ["战士"] = true, -- Chinese (Simplified)
-    ["戰士"] = true, -- Chinese (Traditional)
-
-    ["Paladin"] = true, -- English
-    ["Paladin"] = true, -- German
-    ["Paladín"] = true, -- Spanish
-    ["Paladín"] = true, -- Spanish (Mexico)
-    ["Paladin"] = true, -- French
-    ["Paladino"] = true, -- Italian
-    ["Paladino"] = true, -- Portuguese
-    ["Паладин"] = true, -- Russian
-    ["성기사"] = true, -- Korean
-    ["圣骑士"] = true, -- Chinese (Simplified)
-    ["聖騎士"] = true, -- Chinese (Traditional)
-
-    ["Hunter"] = true, -- English
-    ["Jäger"] = true, -- German
-    ["Cazador"] = true, -- Spanish
-    ["Cazador"] = true, -- Spanish (Mexico)
-    ["Chasseur"] = true, -- French
-    ["Cacciatore"] = true, -- Italian
-    ["Caçador"] = true, -- Portuguese
-    ["Охотник"] = true, -- Russian
-    ["사냥꾼"] = true, -- Korean
-    ["猎人"] = true, -- Chinese (Simplified)
-    ["獵人"] = true, -- Chinese (Traditional)
-
-    ["Rogue"] = true, -- English
-    ["Schurke"] = true, -- German
-    ["Pícaro"] = true, -- Spanish
-    ["Pícaro"] = true, -- Spanish (Mexico)
-    ["Voleur"] = true, -- French
-    ["Ladro"] = true, -- Italian
-    ["Ladino"] = true, -- Portuguese
-    ["Разбойник"] = true, -- Russian
-    ["도적"] = true, -- Korean
-    ["潜行者"] = true, -- Chinese (Simplified)
-    ["盜賊"] = true, -- Chinese (Traditional)
-
-    ["Priest"] = true, -- English
-    ["Priester"] = true, -- German
-    ["Sacerdote"] = true, -- Spanish
-    ["Sacerdote"] = true, -- Spanish (Mexico)
-    ["Prêtre"] = true, -- French
-    ["Sacerdote"] = true, -- Italian
-    ["Sacerdote"] = true, -- Portuguese
-    ["Жрец"] = true, -- Russian
-    ["사제"] = true, -- Korean
-    ["牧师"] = true, -- Chinese (Simplified)
-    ["牧師"] = true, -- Chinese (Traditional)
-
-    ["Shaman"] = true, -- English
-    ["Schamane"] = true, -- German
-    ["Chamán"] = true, -- Spanish
-    ["Chamán"] = true, -- Spanish (Mexico)
-    ["Chaman"] = true, -- French
-    ["Sciamano"] = true, -- Italian
-    ["Xamã"] = true, -- Portuguese
-    ["Шаман"] = true, -- Russian
-    ["주술사"] = true, -- Korean
-    ["萨满祭司"] = true, -- Chinese (Simplified)
-    ["薩滿"] = true, -- Chinese (Traditional)
-
-    ["Mage"] = true, -- English
-    ["Magier"] = true, -- German
-    ["Mago"] = true, -- Spanish
-    ["Mago"] = true, -- Spanish (Mexico)
-    ["Mage"] = true, -- French
-    ["Mago"] = true, -- Italian
-    ["Mago"] = true, -- Portuguese
-    ["Маг"] = true, -- Russian
-    ["마법사"] = true, -- Korean
-    ["法师"] = true, -- Chinese (Simplified)
-    ["法師"] = true, -- Chinese (Traditional)
-
-    ["Warlock"] = true, -- English
-    ["Hexenmeister"] = true, -- German
-    ["Brujo"] = true, -- Spanish
-    ["Brujo"] = true, -- Spanish (Mexico)
-    ["Démoniste"] = true, -- French
-    ["Stregone"] = true, -- Italian
-    ["Bruxo"] = true, -- Portuguese
-    ["Чернокнижник"] = true, -- Russian
-    ["흑마법사"] = true, -- Korean
-    ["术士"] = true, -- Chinese (Simplified)
-    ["術士"] = true, -- Chinese (Traditional)
-
-    ["Druid"] = true, -- English
-    ["Druide"] = true, -- German
-    ["Druida"] = true, -- Spanish
-    ["Druida"] = true, -- Spanish (Mexico)
-    ["Druide"] = true, -- French
-    ["Druido"] = true, -- Italian
-    ["Druida"] = true, -- Portuguese
-    ["Друид"] = true, -- Russian
-    ["드루이드"] = true, -- Korean
-    ["德鲁伊"] = true, -- Chinese (Simplified)
-    ["德魯伊"] = true, -- Chinese (Traditional)
+local helpYourselfSkillsHeadings = {
+    ["Secondary Skills"] = true, -- English
+    ["Nebenfertigkeiten"] = true, -- German
+    ["Habilidades secundarias"] = true, -- Spanish
+    ["Habilidades secundarias"] = true, -- Spanish (Mexico)
+    ["Compétences secondaires"] = true, -- French
+    ["Competenze Secondarie"] = true, -- Italian
+    ["Habilidades secundárias"] = true, -- Portuguese
+    ["Вторичные навыки"] = true, -- Russian
 }
+
+local function getHelpYourselfAllowedCategories()
+    local allowedCategories = {}
+    allowedCategories[WHC.player.class] = true
+
+    local numSkills = GetNumSkillLines();
+    for skillIndex=1, numSkills do
+        local skillName, isHeader, isExpanded, skillRank, numTempPoints, skillModifier,
+        skillMaxRank, isAbandonable, stepCost, rankCost, minLevel, skillCostType,
+        skillDescription = GetSkillLineInfo(skillIndex)
+
+    end
+end
 
 local function getQuestLogTitle(questLogIndex)
     local questTitle, _, _, isHeader, isCollapsed = GetQuestLogTitle(questLogIndex);
@@ -946,7 +860,9 @@ blockQuestsEventListener:SetScript("OnEvent", function()
         end
 
         if not isHeader then
+            if headerName ~= WHC.player.class then
 
+            end
         end
     end
 end)
@@ -956,6 +872,7 @@ function WHC.SetBlockQuests()
         event = "QUEST_ACCEPTED" -- test if this exist on 1.12 even though Chat GPT says it doesn't
     end
     blockQuestsEventListener:UnregisterEvent(event)
+
 
     if WhcAchievementSettings.blockQuests == 1 then
         blockQuestsEventListener:RegisterEvent(event)

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -877,6 +877,54 @@ local helpYourselfAllowedCategories = {
     ["사제"] = true, -- Korean
     ["牧师"] = true, -- Chinese (Simplified)
     ["牧師"] = true, -- Chinese (Traditional)
+
+    ["Shaman"] = true, -- English
+    ["Schamane"] = true, -- German
+    ["Chamán"] = true, -- Spanish
+    ["Chamán"] = true, -- Spanish (Mexico)
+    ["Chaman"] = true, -- French
+    ["Sciamano"] = true, -- Italian
+    ["Xamã"] = true, -- Portuguese
+    ["Шаман"] = true, -- Russian
+    ["주술사"] = true, -- Korean
+    ["萨满祭司"] = true, -- Chinese (Simplified)
+    ["薩滿"] = true, -- Chinese (Traditional)
+
+    ["Mage"] = true, -- English
+    ["Magier"] = true, -- German
+    ["Mago"] = true, -- Spanish
+    ["Mago"] = true, -- Spanish (Mexico)
+    ["Mage"] = true, -- French
+    ["Mago"] = true, -- Italian
+    ["Mago"] = true, -- Portuguese
+    ["Маг"] = true, -- Russian
+    ["마법사"] = true, -- Korean
+    ["法师"] = true, -- Chinese (Simplified)
+    ["法師"] = true, -- Chinese (Traditional)
+
+    ["Warlock"] = true, -- English
+    ["Hexenmeister"] = true, -- German
+    ["Brujo"] = true, -- Spanish
+    ["Brujo"] = true, -- Spanish (Mexico)
+    ["Démoniste"] = true, -- French
+    ["Stregone"] = true, -- Italian
+    ["Bruxo"] = true, -- Portuguese
+    ["Чернокнижник"] = true, -- Russian
+    ["흑마법사"] = true, -- Korean
+    ["术士"] = true, -- Chinese (Simplified)
+    ["術士"] = true, -- Chinese (Traditional)
+
+    ["Druid"] = true, -- English
+    ["Druide"] = true, -- German
+    ["Druida"] = true, -- Spanish
+    ["Druida"] = true, -- Spanish (Mexico)
+    ["Druide"] = true, -- French
+    ["Druido"] = true, -- Italian
+    ["Druida"] = true, -- Portuguese
+    ["Друид"] = true, -- Russian
+    ["드루이드"] = true, -- Korean
+    ["德鲁伊"] = true, -- Chinese (Simplified)
+    ["德魯伊"] = true, -- Chinese (Traditional)
 }
 
 local function getQuestLogTitle(questLogIndex)

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -868,17 +868,16 @@ local previousNumQuests = 0
 local blockQuestsEventListener = CreateFrame("Frame")
 blockQuestsEventListener:SetScript("OnEvent", function(self, eventName, a1)
     eventName = eventName or event
-    WHC.DebugPrint(eventName)
     -- This event is always fired before quest is added to the quest log
     if eventName == "UNIT_QUEST_LOG_CHANGED" then
-        ExpandQuestHeader(0) -- Ensure all quest headers are expanded
-        previousNumQuests = GetNumQuestLogEntries()
+        ExpandQuestHeader(0) -- Ensure dall quest headers are expanded
         return
     end
 
     -- This event is fired multiple times, both before and after a quest is added to the quest log
-    if eventName == "QUEST_LOG_UPDATE" and previousNumQuests ~= GetNumQuestLogEntries() then
-        checkQuests = true
+    if eventName == "QUEST_LOG_UPDATE" then
+        checkQuests = previousNumQuests ~= GetNumQuestLogEntries()
+        previousNumQuests = GetNumQuestLogEntries()
     end
 
     if eventName == "QUEST_ACCEPTED" then

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -864,7 +864,7 @@ local function abandonQuestSound()
 end
 
 local checkQuests = false
-local numQuestsBeforeNewHasBeenAdded = 0
+local previousNumQuests = 0
 local blockQuestsEventListener = CreateFrame("Frame")
 blockQuestsEventListener:SetScript("OnEvent", function(self, eventName, a1)
     eventName = eventName or event
@@ -872,12 +872,12 @@ blockQuestsEventListener:SetScript("OnEvent", function(self, eventName, a1)
     -- This event is always fired before quest is added to the quest log
     if eventName == "UNIT_QUEST_LOG_CHANGED" then
         ExpandQuestHeader(0) -- Ensure all quest headers are expanded
-        numQuestsBeforeNewHasBeenAdded = GetNumQuestLogEntries()
+        previousNumQuests = GetNumQuestLogEntries()
         return
     end
 
     -- This event is fired multiple times, both before and after a quest is added to the quest log
-    if eventName == "QUEST_LOG_UPDATE" and numQuestsBeforeNewHasBeenAdded < GetNumQuestLogEntries() then
+    if eventName == "QUEST_LOG_UPDATE" and previousNumQuests ~= GetNumQuestLogEntries() then
         checkQuests = true
     end
 

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -813,3 +813,11 @@ function WHC.SetBlockRidingSkill()
 end
 
 --endregion
+
+--region ====== Help Yourself ======
+local helpYourselfLink = WHC.Achievements.HELP_YOURSELF.itemLink
+
+function WHC.SetBlockQuests()
+
+end
+--endregion

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -870,7 +870,7 @@ blockQuestsEventListener:SetScript("OnEvent", function(self, eventName, a1)
     eventName = eventName or event
     -- This event is always fired before quest is added to the quest log
     if eventName == "UNIT_QUEST_LOG_CHANGED" then
-        ExpandQuestHeader(0) -- Ensure dall quest headers are expanded
+        ExpandQuestHeader(0) -- Ensure all quest headers are expanded
         return
     end
 

--- a/Init.lua
+++ b/Init.lua
@@ -70,6 +70,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WhcAchievementSettings.blockNonSelfMadeItemsTooltip = WhcAchievementSettings.blockNonSelfMadeItemsTooltip or 0
     WhcAchievementSettings.blockMailItems = WhcAchievementSettings.blockMailItems or 0
     WhcAchievementSettings.blockRidingSkill = WhcAchievementSettings.blockRidingSkill or 0
+    WhcAchievementSettings.blockQuests = WhcAchievementSettings.blockQuests or 0
 
     WHC.InitializeUI()
     WHC.InitializeMinimapIcon()
@@ -120,6 +121,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WHC.SetBlockRepair()
     WHC.SetBlockTaxiService()
     WHC.SetBlockMailItems()
+    WHC.SetBlockQuests()
     if RETAIL == 0 then
         WHC.SetBlockEquipItems()
     end

--- a/Init.lua
+++ b/Init.lua
@@ -24,8 +24,10 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
         return
     end
 
+    local class = UnitClass("player")
     WHC.player = {
         name = UnitName("player"),
+        class = class,
     }
 
     local version = GetBuildInfo()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 ## Changelog for next update
-- Settings checkbox for Help Yourself achievement, auto abandoning quests
+- Settings checkbox for Help Yourself achievement, auto abandoning non-class or profession quests
 
 ## Future versions:
 - Prevent/disable auto-run when you are on a flypath

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 ## Changelog for next update
-
+- Settings checkbox for Help Yourself achievement, auto abandoning quests
 
 ## Future versions:
 - Prevent/disable auto-run when you are on a flypath

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -157,7 +157,7 @@ function WHC.Tab_Settings(content)
         WHC.SetBlockTaxiService()
     end)
 
-    WHC_SETTINGS.blockQuestsCheckbox = createSettingsCheckBox(scrollContent, "[Help Yourself] Achievement: Auto-abandon illegal quests")
+    WHC_SETTINGS.blockQuestsCheckbox = createSettingsCheckBox(scrollContent, "[Help Yourself] Achievement: Auto-abandon non-class or profession quests")
     WHC_SETTINGS.blockQuestsCheckbox:SetScript("OnClick", function(self)
         WhcAchievementSettings.blockQuests = math.abs(WhcAchievementSettings.blockQuests - 1)
         playCheckedSound(WhcAchievementSettings.blockQuests)

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -157,6 +157,13 @@ function WHC.Tab_Settings(content)
         WHC.SetBlockTaxiService()
     end)
 
+    WHC_SETTINGS.blockQuestsCheckbox = createSettingsCheckBox(scrollContent, "[Help Yourself] Achievement: Auto-abandon illegal quests")
+    WHC_SETTINGS.blockQuestsCheckbox:SetScript("OnClick", function(self)
+        WhcAchievementSettings.blockQuests = math.abs(WhcAchievementSettings.blockQuests - 1)
+        playCheckedSound(WhcAchievementSettings.blockQuests)
+        WHC.SetBlockQuests()
+    end)
+
     WHC_SETTINGS.blockRepairCheckbox = createSettingsCheckBox(scrollContent, "[Iron Bones] Achievement: Block repairing items")
     WHC_SETTINGS.blockRepairCheckbox:SetScript("OnClick", function(self)
         WhcAchievementSettings.blockRepair = math.abs(WhcAchievementSettings.blockRepair - 1)

--- a/UI.lua
+++ b/UI.lua
@@ -75,6 +75,7 @@ function WHC.UIShowTabContent(tabIndex, arg1)
             WHC_SETTINGS.blockTaxiServiceCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTaxiService))
             WHC_SETTINGS.blockMailItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMailItems))
             WHC_SETTINGS.blockRidingSkillCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRidingSkill))
+            WHC_SETTINGS.blockQuestsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockQuests))
 
             if RETAIL == 0 then
                 WHC_SETTINGS.blockMagicItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMagicItems))


### PR DESCRIPTION
Added support for the Help Yourself achievment. I managed to do it with minimal translation logic needed.

The only way to check the category of a quest is to look at the heading once the quest is in the quest log.

1. Listen for events telling me a new quest has been added
2. Expand all quests categories to be able to read the quest names
3. Find the header and check if it is valid.
4. Abandon all quests beneath that header if it is not allowed.

To find the valid categories I did the following:
* For the class I just used `UnitClass()` as it returns both the lokalised and the english name for the class.
* I find the players primary professions, lokalised thanks to the `GetSkillLineInfo()` function by looking if the skill can be abandonned, as only primary professions can be abandoned.
* For the secondary professions I chose to use translations to keep the logic readable and similar to the primary professions
  * The translations does not work for Korean, Chinese (Simple) or Chinese (Traditional) as I cannot read the signs on wowhead.
  * If we _**really**_ want to avoid translations, then we can look at the spellbook and interate over all the spells on the general tab, and look for icons that matches fishing, first aid, and cooking. It is a bit more troublesome but it can be done.