### PR TITLE
New Feature: Soft Hands Achievment

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -710,6 +710,20 @@ local marathonRunnerBlockedQuests = {
     ["召喚地獄戰馬"]                    = true, -- Chinese (Traditional)
 }
 
+local function getTrainerServiceCost(skillIndex)
+    local money, _, professionSlots = GetTrainerServiceCost(skillIndex)
+    if RETAIL == 1 then
+        money, professionSlots = GetTrainerServiceCost(skillIndex)
+        if professionSlots then -- 1.14 returns a bool instead of an integer
+            professionSlots = 1
+        else
+            professionSlots = 0
+        end
+    end
+
+    return money, professionSlots
+end
+
 --Base cost is 80 gold (800000 cp)
 --10% discount is 72 gold (720000 cp)
 --20% discount is 64 gold (640000 cp)
@@ -719,13 +733,13 @@ local function canTrainSkill()
     local trainSkillErrorMessages = {}
 
     local skillIndex = GetTrainerSelectionIndex()
-    local money, _, profession = GetTrainerServiceCost(skillIndex)
+    local money, professionSlots = getTrainerServiceCost(skillIndex)
 
     if WhcAchievementSettings.blockRidingSkill == 1 and money > ridingCostInCopper then
         table.insert(trainSkillErrorMessages, achievementErrorMessage(marathonRunnerLink, "Buying riding skill is blocked."))
     end
 
-    if WhcAchievementSettings.blockProfessions == 1 and profession > 0 then
+    if WhcAchievementSettings.blockProfessions == 1 and professionSlots > 0 then
         table.insert(trainSkillErrorMessages, achievementErrorMessage(softHandsLink, "Buying primary profession is blocked."))
     end
 

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -721,8 +721,6 @@ local function canTrainSkill()
     local skillIndex = GetTrainerSelectionIndex()
     local money, _, profession = GetTrainerServiceCost(skillIndex)
 
-    WHC.DebugPrint(string.format("GetTrainerServiceCost money:%s profession:%s", tostring(money), tostring(profession)))
-
     if WhcAchievementSettings.blockRidingSkill == 1 and money > ridingCostInCopper then
         table.insert(trainSkillErrorMessages, achievementErrorMessage(marathonRunnerLink, "Buying riding skill is blocked."))
     end

--- a/Init.lua
+++ b/Init.lua
@@ -72,6 +72,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WhcAchievementSettings.blockNonSelfMadeItemsTooltip = WhcAchievementSettings.blockNonSelfMadeItemsTooltip or 0
     WhcAchievementSettings.blockMailItems = WhcAchievementSettings.blockMailItems or 0
     WhcAchievementSettings.blockRidingSkill = WhcAchievementSettings.blockRidingSkill or 0
+    WhcAchievementSettings.blockProfessions = WhcAchievementSettings.blockProfessions or 0
     WhcAchievementSettings.blockQuests = WhcAchievementSettings.blockQuests or 0
 
     WHC.InitializeUI()
@@ -123,7 +124,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WHC.SetBlockRepair()
     WHC.SetBlockTaxiService()
     WHC.SetBlockMailItems()
-    WHC.SetBlockRidingSkill()
+    WHC.SetBlockTrainSkill()
     WHC.SetBlockQuests()
     if RETAIL == 0 then
         WHC.SetBlockEquipItems()

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ## Changelog for next update
 - Settings checkbox for Marathon Runner achievement, blocking learning riding skill
 - Settings checkbox for Help Yourself achievement, auto abandoning non-class or profession quests
+- Settings checkbox for Soft Hands achievement, blocking learning primary professions
 
 ## Future versions:
 - Prevent/disable auto-run when you are on a flypath

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -189,7 +189,7 @@ function WHC.Tab_Settings(content)
     WHC_SETTINGS.blockRidingSkillCheckbox:SetScript("OnClick", function(self)
         WhcAchievementSettings.blockRidingSkill = math.abs(WhcAchievementSettings.blockRidingSkill - 1)
         playCheckedSound(WhcAchievementSettings.blockRidingSkill)
-        WHC.SetBlockRidingSkill()
+        WHC.SetBlockTrainSkill()
     end)
 
     if RETAIL == 0 then
@@ -262,6 +262,13 @@ function WHC.Tab_Settings(content)
             playCheckedSound(WhcAchievementSettings.blockNonSelfMadeItemsTooltip)
         end)
     end
+
+    WHC_SETTINGS.blockProfessionsCheckbox = createSettingsCheckBox(scrollContent, "[Soft Hands] Achievement: Block learning primary professions")
+    WHC_SETTINGS.blockProfessionsCheckbox:SetScript("OnClick", function(self)
+        WhcAchievementSettings.blockProfessions = math.abs(WhcAchievementSettings.blockProfessions - 1)
+        playCheckedSound(WhcAchievementSettings.blockProfessions)
+        WHC.SetBlockTrainSkill()
+    end)
 
     WHC_SETTINGS.blockMailItemsCheckbox = createSettingsCheckBox(scrollContent, "[Special Deliveries] Achievement: Block mail items and money")
     WHC_SETTINGS.blockMailItemsCheckbox:SetScript("OnClick", function(self)

--- a/UI.lua
+++ b/UI.lua
@@ -75,6 +75,7 @@ function WHC.UIShowTabContent(tabIndex, arg1)
             WHC_SETTINGS.blockTaxiServiceCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTaxiService))
             WHC_SETTINGS.blockMailItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMailItems))
             WHC_SETTINGS.blockRidingSkillCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRidingSkill))
+            WHC_SETTINGS.blockProfessionsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockProfessions))
             WHC_SETTINGS.blockQuestsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockQuests))
 
             if RETAIL == 0 then


### PR DESCRIPTION
## New Feature
- Added settings checkbox
- Logic for soft hands achievement
- Updated changelog

## Refactors
- Generalized `printBlockers` so it can be used for Soft Hands and Marathon Runner achievements
- Removed the need for lokalization for Apprentice Riding
  - This logic assumes that no other trainer skill costs 64 gold or more. So no adding super expensive custom trainer skills!
- Change the logic for `BuyTrainerService()` and `ClassTrainerTrainButton` to check for both Soft Hands and Marathong Runner
- Change the `SetBlockRiding()` name to `SetBlockTrainSkill()` as it better fits the wider logic needed for two achievements.
  - This is the same approach for Self-made, Mister White and Only Fan.