### PR TITLE
[New Feature] Report right-click opens support ticket

### DIFF
--- a/Init.lua
+++ b/Init.lua
@@ -104,18 +104,7 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WHC.InitializeMinimapIcon()
     WHC.InitializeDeathLogFrame()
     WHC.InitializeAchievementButtons()
-
-    if (RETAIL == 1) then
-        -- todo (low prio since ticket status block not displayed on retail)
-    else
-        StaticPopupDialogs["HELP_TICKET"].OnAccept = function()
-            WHC.UIShowTabContent("Support")
-        end
-
-        StaticPopupDialogs["HELP_TICKET"].OnCancel = function()
-            WHC.UIShowTabContent("Support")
-        end
-    end
+    WHC.InitializeSupport()
 
     if (WhcAddonSettings.minimapicon == 1) then
         WHC.Frames.MapIcon:Show()

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 - Settings checkbox for Untalented achievement, blocking learning talents
 - Pressing ESC now closes the addon
 - Added sounds for opening and closing the addon, as well as selecting tabs
+- Opens the Addon ticket system when right-clicking a player to report them.
 
 ## Future versions:
-- Disable the complaint system (right click on chat or character to report it) as report aren't sent to the server. Open the addon ticket form instead.
 - Prevent/disable auto-run when you are on a flypath
 - /world join after a few seconds to prevent replacing general
 - settings checkbox to allow /creature say to only display death announcements

--- a/Support.lua
+++ b/Support.lua
@@ -1,10 +1,44 @@
-local originalHelpButton_OnClick = HelpMicroButton:GetScript("OnClick")
+function WHC.InitializeSupport()
+    local supportTabIndex = "Support"
 
-HelpMicroButton:SetScript("OnClick", function()
-    if WHC:IsVisible() then
-        WHC.UIShowTabContent(0)
+    --  Both clients: The ? button on the default UI
+    HelpMicroButton:SetScript("OnClick", function()
+        if WHC.Frames.UItab[supportTabIndex]:IsVisible() then
+            WHC.UIShowTabContent(0)
+        else
+            WHC.UIShowTabContent(supportTabIndex)
+        end
+    end)
+
+    -- 1.12: The active ticket button above buffs
+    if (RETAIL == 1) then
+        -- todo (low prio since ticket status block not displayed on retail)
     else
-        WHC.UIShowTabContent("Support")
-    end
-end)
+        StaticPopupDialogs["HELP_TICKET"].OnAccept = function()
+            WHC.UIShowTabContent(supportTabIndex)
+        end
 
+        StaticPopupDialogs["HELP_TICKET"].OnCancel = function()
+            WHC.UIShowTabContent(supportTabIndex)
+        end
+    end
+
+    local reportOptions = {
+        ["REPORT_SPAM"] = true,
+        ["REPORT_BAD_LANGUAGE"] = true,
+        ["REPORT_BAD_NAME"] = true,
+        ["REPORT_CHEATING"] = true,
+    }
+
+    -- 1.14: Right-clicking on a player to report them
+    WHC.HookSecureFunc("UnitPopup_OnUpdate", function(self, dropdownMenu, which, unit, name)
+        for i = 1, UIDROPDOWNMENU_MAXBUTTONS do
+            local button = getglobal("DropDownList2Button" .. i)
+            if button and reportOptions[button.value] then
+                button:SetScript("OnClick", function()
+                    WHC.UIShowTabContent(supportTabIndex)
+                end)
+            end
+        end
+    end)
+end


### PR DESCRIPTION
- Moved all support related logic to the `Support.lua` file
- Right-clicking a player to report them now uses the addon ticket system instead of sending the message to "Blizzard"
- If the Addon is open and you click the ? button on the defualt UI, the Support tab opens if it is not selected. Else the addon closes.