### PR TITLE
[Refactor/Improvement] Deathpop up and appeal button

### DIFF
--- a/Death.lua
+++ b/Death.lua
@@ -61,7 +61,9 @@ local function createUrlFrame()
     return urlFrame
 end
 
-local function addDeathPopupAppealButton(urlFrame)
+local function addDeathPopupAppealButton()
+    local urlFrame = createUrlFrame()
+
     local deathOverride = function (data, reason)
         if (reason == "override") then
             return
@@ -78,6 +80,7 @@ local function addDeathPopupAppealButton(urlFrame)
     else
         StaticPopupDialogs["DEATH"].OnCancel = deathOverride
     end
+    StaticPopupDialogs["DEATH"].DisplayButton2 = function() return true end
 end
 
 local function updateDeathPopupText()
@@ -90,22 +93,18 @@ local function updateDeathPopupText()
             StaticPopupDialogs["DEATH"].text = "YOU DIED";
             StaticPopupDialogs["DEATH"].button1 = "Release Spirit";
             StaticPopupDialogs["DEATH"].button2 = "";
-            StaticPopupDialogs["DEATH"].DisplayButton2 = function()
-                return false
-            end
+            StaticPopupDialogs["DEATH"].DisplayButton2 = function() return false end
         else
             DEATH_RELEASE = "Go again";
             StaticPopupDialogs["DEATH"].text = "|cffff0000YOU DIED|r";
             StaticPopupDialogs["DEATH"].button1 = "Go again";
             StaticPopupDialogs["DEATH"].button2 = "Appeal";
-            StaticPopupDialogs["DEATH"].DisplayButton2 = function()
-                return true
-            end
+            StaticPopupDialogs["DEATH"].DisplayButton2 = function() return true end
         end
     end)
 end
 
 function WHC.InitializeDeathPopupAppeal()
-    addDeathPopupAppealButton(createUrlFrame())
+    addDeathPopupAppealButton()
     updateDeathPopupText()
 end

--- a/Death.lua
+++ b/Death.lua
@@ -1,10 +1,9 @@
-local function createUrlFrame()
-    -- Create the URL frame
-    local urlFrame = CreateFrame("Frame", "URLFrame", UIParent, RETAIL_BACKDROP)
-    urlFrame:SetWidth(300)
-    urlFrame:SetHeight(150)
-    urlFrame:SetPoint("TOP", UIParent, "TOP", 0, -128)
-    urlFrame:SetBackdrop({
+local function createAppealFrame()
+    local appealFrame = CreateFrame("Frame", "AppealFrame", UIParent, RETAIL_BACKDROP)
+    appealFrame:SetWidth(300)
+    appealFrame:SetHeight(150)
+    appealFrame:SetPoint("TOP", UIParent, "TOP", 0, -128)
+    appealFrame:SetBackdrop({
         bgFile = "Interface/RaidFrame/UI-RaidFrame-GroupBg",
         edgeFile = "Interface/DialogFrame/UI-DialogBox-Border",
         tile = true,
@@ -13,37 +12,37 @@ local function createUrlFrame()
         insets = { left = 11, right = 12, top = 12, bottom = 11 }
     })
 
-    urlFrame:SetFrameStrata("HIGH")
-    urlFrame:SetFrameLevel(10)
+    appealFrame:SetFrameStrata("HIGH")
+    appealFrame:SetFrameLevel(10)
 
     -- Title
-    local title = urlFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-    title:SetPoint("TOP", urlFrame, "TOP", 0, -20)
+    local title = appealFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    title:SetPoint("TOP", appealFrame, "TOP", 0, -20)
     title:SetText("Copy and paste the following URL to your browser to appeal")
     title:SetWidth(200)
 
     -- URL input box
-    local urlEditBox = CreateFrame("EditBox", "URLInputBox", urlFrame)
-    urlEditBox:SetWidth(250)
-    urlEditBox:SetHeight(20)
-    urlEditBox:SetPoint("TOP", title, "BOTTOM", 0, -20)
-    urlEditBox:SetFontObject("ChatFontNormal")
-    urlEditBox:SetText("https://wow-hc.com/appeal")
-    urlEditBox:SetJustifyH("CENTER")
-    urlEditBox:SetAutoFocus(false)
-    urlEditBox:HighlightText()
-    urlEditBox:SetFocus()
-    urlEditBox:SetTextColor(1, 0.631, 0.317)
-    urlEditBox:SetScript("OnMouseDown", function(self)
-        urlEditBox:HighlightText()
-        urlEditBox:SetFocus()
+    local appealEditBox = CreateFrame("EditBox", "AppealInputBox", appealFrame)
+    appealEditBox:SetWidth(250)
+    appealEditBox:SetHeight(20)
+    appealEditBox:SetPoint("TOP", title, "BOTTOM", 0, -20)
+    appealEditBox:SetFontObject("ChatFontNormal")
+    appealEditBox:SetText("https://wow-hc.com/appeal")
+    appealEditBox:SetJustifyH("CENTER")
+    appealEditBox:SetAutoFocus(false)
+    appealEditBox:HighlightText()
+    appealEditBox:SetFocus()
+    appealEditBox:SetTextColor(1, 0.631, 0.317)
+    appealEditBox:SetScript("OnMouseDown", function(self)
+        appealEditBox:HighlightText()
+        appealEditBox:SetFocus()
     end)
 
     -- Create a container for the buttons to manage their positioning
-    local buttonContainer = CreateFrame("Frame", nil, urlFrame)
+    local buttonContainer = CreateFrame("Frame", nil, appealFrame)
     buttonContainer:SetWidth(250) -- Width enough to fit both buttons
     buttonContainer:SetHeight(30) -- Height of the buttons
-    buttonContainer:SetPoint("TOP", urlEditBox, "BOTTOM", 0, -20)
+    buttonContainer:SetPoint("TOP", appealEditBox, "BOTTOM", 0, -20)
 
     -- Cancel button
     local cancelButton = CreateFrame("Button", nil, buttonContainer, "UIPanelButtonTemplate")
@@ -52,17 +51,17 @@ local function createUrlFrame()
     cancelButton:SetPoint("CENTER", buttonContainer, "CENTER", 5, 0) -- Position relative to container's center
     cancelButton:SetText("Back")
     cancelButton:SetScript("OnClick", function()
-        urlFrame:Hide()
+        appealFrame:Hide()
         StaticPopup_Show("DEATH");
     end)
 
-    urlFrame:Hide()
+    appealFrame:Hide()
 
-    return urlFrame
+    return appealFrame
 end
 
 local function addDeathPopupAppealButton()
-    local urlFrame = createUrlFrame()
+    local appealFrame = createAppealFrame()
 
     local deathOverride = function (data, reason)
         if (reason == "override") then
@@ -72,7 +71,7 @@ local function addDeathPopupAppealButton()
             return
         end
 
-        urlFrame:Show()
+        appealFrame:Show()
     end
 
     if (RETAIL == 1) then

--- a/Death.lua
+++ b/Death.lua
@@ -1,199 +1,111 @@
-function WHC.UpdateDeathWindow(pvp)
+local function createUrlFrame()
+    -- Create the URL frame
+    local urlFrame = CreateFrame("Frame", "URLFrame", UIParent, RETAIL_BACKDROP)
+    urlFrame:SetWidth(300)
+    urlFrame:SetHeight(150)
+    urlFrame:SetPoint("TOP", UIParent, "TOP", 0, -128)
+    urlFrame:SetBackdrop({
+        bgFile = "Interface/RaidFrame/UI-RaidFrame-GroupBg",
+        edgeFile = "Interface/DialogFrame/UI-DialogBox-Border",
+        tile = true,
+        tileSize = 300,
+        edgeSize = 32,
+        insets = { left = 11, right = 12, top = 12, bottom = 11 }
+    })
 
-    if (pvp) then
+    urlFrame:SetFrameStrata("HIGH")
+    urlFrame:SetFrameLevel(10)
 
-        DEATH_RELEASE = "Release Spirit";
-        StaticPopupDialogs["DEATH"].text = "YOU DIED";
-        StaticPopupDialogs["DEATH"].button1 = "Release Spirit";
-        StaticPopupDialogs["DEATH"].button2 = "";
+    -- Title
+    local title = urlFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    title:SetPoint("TOP", urlFrame, "TOP", 0, -20)
+    title:SetText("Copy and paste the following URL to your browser to appeal")
+    title:SetWidth(200)
 
-        StaticPopupDialogs["DEATH"].DisplayButton2 = function()
-            return false
-        end
-    else
-        DEATH_RELEASE = "Go again";
-        StaticPopupDialogs["DEATH"].text = "|cffff0000YOU DIED|r";
-        StaticPopupDialogs["DEATH"].button1 = "Go again";
-        StaticPopupDialogs["DEATH"].button2 = "Appeal";
+    -- URL input box
+    local urlEditBox = CreateFrame("EditBox", "URLInputBox", urlFrame)
+    urlEditBox:SetWidth(250)
+    urlEditBox:SetHeight(20)
+    urlEditBox:SetPoint("TOP", title, "BOTTOM", 0, -20)
+    urlEditBox:SetFontObject("ChatFontNormal")
+    urlEditBox:SetText("https://wow-hc.com/appeal")
+    urlEditBox:SetJustifyH("CENTER")
+    urlEditBox:SetAutoFocus(false)
+    urlEditBox:HighlightText()
+    urlEditBox:SetFocus()
+    urlEditBox:SetTextColor(1, 0.631, 0.317)
+    urlEditBox:SetScript("OnMouseDown", function(self)
+        urlEditBox:HighlightText()
+        urlEditBox:SetFocus()
+    end)
 
-        StaticPopupDialogs["DEATH"].DisplayButton2 = function()
-            return true
-        end
-    end
-end
+    -- Create a container for the buttons to manage their positioning
+    local buttonContainer = CreateFrame("Frame", nil, urlFrame)
+    buttonContainer:SetWidth(250) -- Width enough to fit both buttons
+    buttonContainer:SetHeight(30) -- Height of the buttons
+    buttonContainer:SetPoint("TOP", urlEditBox, "BOTTOM", 0, -20)
 
--- WHC.UpdateDeathWindow(false);
-
-
-local function showDeathWindow(show)
-    if (RETAIL == 1) then
-        StaticPopupDialogs["DEATH"].OnButton2 = function(data, reason)
-            if (reason == "override") then
-                return
-            end
-            if (reason == "timeout") then
-                return
-            end
-
-            -- Create the URL frame
-            local urlFrame = CreateFrame("Frame", "URLFrame", UIParent, RETAIL_BACKDROP)
-            urlFrame:SetWidth(300)
-            urlFrame:SetHeight(150)
-            urlFrame:SetPoint("TOP", UIParent, "TOP", 0, -128)
-            urlFrame:SetBackdrop({
-                bgFile = "Interface/RaidFrame/UI-RaidFrame-GroupBg",
-                edgeFile = "Interface/DialogFrame/UI-DialogBox-Border",
-                tile = true,
-                tileSize = 300,
-                edgeSize = 32,
-                insets = { left = 11, right = 12, top = 12, bottom = 11 }
-            })
-
-            urlFrame:SetFrameStrata("HIGH")
-            urlFrame:SetFrameLevel(10)
-
-            -- Title
-            local title = urlFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-            title:SetPoint("TOP", urlFrame, "TOP", 0, -20)
-            title:SetText("Copy and paste the following URL to your browser to appeal")
-            title:SetWidth(200)
-
-            -- URL input box
-            local urlEditBox = CreateFrame("EditBox", "URLInputBox", urlFrame)
-            urlEditBox:SetWidth(250)
-            urlEditBox:SetHeight(20)
-            urlEditBox:SetPoint("TOP", title, "BOTTOM", 0, -20)
-            urlEditBox:SetFontObject("ChatFontNormal")
-            urlEditBox:SetText("https://wow-hc.com/appeal")
-            urlEditBox:SetJustifyH("CENTER")
-            urlEditBox:SetAutoFocus(false)
-            urlEditBox:HighlightText()
-            urlEditBox:SetFocus()
-            urlEditBox:SetTextColor(1, 0.631, 0.317)
-            urlEditBox:SetScript("OnMouseDown", function(self)
-                urlEditBox:HighlightText()
-                urlEditBox:SetFocus()
-            end)
-
-            -- Create a container for the buttons to manage their positioning
-            local buttonContainer = CreateFrame("Frame", nil, urlFrame)
-            buttonContainer:SetWidth(250) -- Width enough to fit both buttons
-            buttonContainer:SetHeight(30) -- Height of the buttons
-            buttonContainer:SetPoint("TOP", urlEditBox, "BOTTOM", 0, -20)
-
-            -- Copy button
-            -- local copyButton = CreateFrame("Button", nil, buttonContainer, "UIPanelButtonTemplate")
-            -- copyButton:SetWidth(120)
-            -- copyButton:SetHeight(30)
-            -- copyButton:SetPoint("RIGHT", buttonContainer, "CENTER", -5, 0) -- Position relative to container's center
-            -- copyButton:SetText("Select Text")
-            -- copyButton:SetScript("OnClick", function()
-            --     urlEditBox:HighlightText()
-            --    urlEditBox:SetFocus()
-            --    WHC.DebugPrint("URL text selected. Please use Ctrl+C to copy.")
-            --end)
-
-            -- Cancel button
-            local cancelButton = CreateFrame("Button", nil, buttonContainer, "UIPanelButtonTemplate")
-            cancelButton:SetWidth(80)
-            cancelButton:SetHeight(30)
-            cancelButton:SetPoint("CENTER", buttonContainer, "CENTER", 5, 0) -- Position relative to container's center
-            cancelButton:SetText("Back")
-            cancelButton:SetScript("OnClick", function()
-                urlFrame:Hide()
-                showDeathWindow(true);
-            end)
-
-            -- Show the frame
-            urlFrame:Show()
-        end
-    else
-        StaticPopupDialogs["DEATH"].OnCancel = function(data, reason)
-            if (reason == "override") then
-                return
-            end
-            if (reason == "timeout") then
-                return
-            end
-            if (reason == "clicked") then
-                -- Create the URL frame
-                local urlFrame = CreateFrame("Frame", "URLFrame", UIParent, RETAIL_BACKDROP)
-                urlFrame:SetWidth(300)
-                urlFrame:SetHeight(150)
-                urlFrame:SetPoint("TOP", UIParent, "TOP", 0, -128)
-                urlFrame:SetBackdrop({
-                    bgFile = "Interface/RaidFrame/UI-RaidFrame-GroupBg",
-                    edgeFile = "Interface/DialogFrame/UI-DialogBox-Border",
-                    tile = true,
-                    tileSize = 300,
-                    edgeSize = 32,
-                    insets = { left = 11, right = 12, top = 12, bottom = 11 }
-                })
-
-                urlFrame:SetFrameStrata("HIGH")
-                urlFrame:SetFrameLevel(10)
-
-                -- Title
-                local title = urlFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-                title:SetPoint("TOP", urlFrame, "TOP", 0, -20)
-                title:SetText("Copy and paste the following URL to your browser to appeal")
-                title:SetWidth(200)
-
-                -- URL input box
-                local urlEditBox = CreateFrame("EditBox", "URLInputBox", urlFrame)
-                urlEditBox:SetWidth(250)
-                urlEditBox:SetHeight(20)
-                urlEditBox:SetPoint("TOP", title, "BOTTOM", 0, -20)
-                urlEditBox:SetFontObject("ChatFontNormal")
-                urlEditBox:SetText("https://wow-hc.com/appeal")
-                urlEditBox:SetJustifyH("CENTER")
-                urlEditBox:SetAutoFocus(false)
-                urlEditBox:HighlightText()
-                urlEditBox:SetFocus()
-                urlEditBox:SetTextColor(1, 0.631, 0.317)
-                urlEditBox:SetScript("OnMouseDown", function(self)
-                    urlEditBox:HighlightText()
-                    urlEditBox:SetFocus()
-                end)
-
-                -- Create a container for the buttons to manage their positioning
-                local buttonContainer = CreateFrame("Frame", nil, urlFrame)
-                buttonContainer:SetWidth(250) -- Width enough to fit both buttons
-                buttonContainer:SetHeight(30) -- Height of the buttons
-                buttonContainer:SetPoint("TOP", urlEditBox, "BOTTOM", 0, -20)
-
-                -- Copy button
-                -- local copyButton = CreateFrame("Button", nil, buttonContainer, "UIPanelButtonTemplate")
-                -- copyButton:SetWidth(120)
-                -- copyButton:SetHeight(30)
-                -- copyButton:SetPoint("RIGHT", buttonContainer, "CENTER", -5, 0) -- Position relative to container's center
-                -- copyButton:SetText("Select Text")
-                -- copyButton:SetScript("OnClick", function()
-                --     urlEditBox:HighlightText()
-                --    urlEditBox:SetFocus()
-                --    WHC.DebugPrint("URL text selected. Please use Ctrl+C to copy.")
-                --end)
-
-                -- Cancel button
-                local cancelButton = CreateFrame("Button", nil, buttonContainer, "UIPanelButtonTemplate")
-                cancelButton:SetWidth(80)
-                cancelButton:SetHeight(30)
-                cancelButton:SetPoint("CENTER", buttonContainer, "CENTER", 5, 0) -- Position relative to container's center
-                cancelButton:SetText("Back")
-                cancelButton:SetScript("OnClick", function()
-                    urlFrame:Hide()
-                    showDeathWindow(true);
-                end)
-
-                -- Show the frame
-                urlFrame:Show()
-            end
-        end
-    end
-
-    if (show) then
+    -- Cancel button
+    local cancelButton = CreateFrame("Button", nil, buttonContainer, "UIPanelButtonTemplate")
+    cancelButton:SetWidth(80)
+    cancelButton:SetHeight(30)
+    cancelButton:SetPoint("CENTER", buttonContainer, "CENTER", 5, 0) -- Position relative to container's center
+    cancelButton:SetText("Back")
+    cancelButton:SetScript("OnClick", function()
+        urlFrame:Hide()
         StaticPopup_Show("DEATH");
+    end)
+
+    urlFrame:Hide()
+
+    return urlFrame
+end
+
+local function addDeathPopupAppealButton(urlFrame)
+    local deathOverride = function (data, reason)
+        if (reason == "override") then
+            return
+        end
+        if (reason == "timeout") then
+            return
+        end
+
+        urlFrame:Show()
+    end
+
+    if (RETAIL == 1) then
+        StaticPopupDialogs["DEATH"].OnButton2 = deathOverride
+    else
+        StaticPopupDialogs["DEATH"].OnCancel = deathOverride
     end
 end
 
-showDeathWindow(false);
+local function updateDeathPopupText()
+    local mapChangeEventHandler = CreateFrame("Frame")
+    mapChangeEventHandler:RegisterEvent("PLAYER_ENTERING_WORLD")
+    mapChangeEventHandler:SetScript("OnEvent", function(self, event)
+        local _, instanceType = IsInInstance()
+        if (instanceType == "pvp") then
+            DEATH_RELEASE = "Release Spirit";
+            StaticPopupDialogs["DEATH"].text = "YOU DIED";
+            StaticPopupDialogs["DEATH"].button1 = "Release Spirit";
+            StaticPopupDialogs["DEATH"].button2 = "";
+            StaticPopupDialogs["DEATH"].DisplayButton2 = function()
+                return false
+            end
+        else
+            DEATH_RELEASE = "Go again";
+            StaticPopupDialogs["DEATH"].text = "|cffff0000YOU DIED|r";
+            StaticPopupDialogs["DEATH"].button1 = "Go again";
+            StaticPopupDialogs["DEATH"].button2 = "Appeal";
+            StaticPopupDialogs["DEATH"].DisplayButton2 = function()
+                return true
+            end
+        end
+    end)
+end
+
+function WHC.InitializeDeathPopupAppeal()
+    addDeathPopupAppealButton(createUrlFrame())
+    updateDeathPopupText()
+end

--- a/Events.lua
+++ b/Events.lua
@@ -118,19 +118,6 @@ function MoneyFrame_Update(frameName, money)
     end
 end
 
-local mapChangeEventHandler = CreateFrame("Frame")
-mapChangeEventHandler:RegisterEvent("PLAYER_ENTERING_WORLD")
-mapChangeEventHandler:SetScript("OnEvent", function(self, event)
-    local inInstance, instanceType = IsInInstance()
-    -- message(instanceType)
-    if (instanceType == "pvp") then
-        WHC.UpdateDeathWindow(true)
-    else
-        WHC.UpdateDeathWindow(false)
-    end
-end)
-
-
 local function handleChatEvent(arg1)
     local lowerArg = string.lower(arg1)
     if not string.find(lowerArg, "^::whc::") then

--- a/Init.lua
+++ b/Init.lua
@@ -53,8 +53,17 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     }
 
     local locale = GetLocale()
+    local is1_12 = version == "1.12.0" or version == "1.12.1"
     WHC.client = {
-        isEnglish = locale == "enUS" or locale == "enGB"
+        isEnglish = locale == "enUS" or locale == "enGB",
+        is1_12 = is1_12,
+        is1_14 = not is1_12
+    }
+
+    local realmName = GetRealmName()
+    WHC.server = {
+        name = realmName,
+        isHardcore = realmName == "Permadeath - EU"
     }
 
     WHC.sounds = {
@@ -107,6 +116,10 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WHC.InitializeSupport()
     WHC.InitializeDynamicMounts()
     WHC.InitializeTradableRaidLoot()
+
+    if WHC.server.isHardcore then
+        WHC.InitializeDeathPopupAppeal()
+    end
 
     local msg = ".whc version " .. GetAddOnMetadata("WOW_HC", "Version")
     if (RETAIL == 1) then

--- a/Tabs/Achievements.lua
+++ b/Tabs/Achievements.lua
@@ -106,8 +106,6 @@ function WHC.ToggleAchievement(itemAch, failed)
     end
 end
 
-WHC.Frames.Achievements = {}
-
 WHC.Achievements = {
     DEMON_SLAYER           = { id = 16384, icon = "spell_shadow_unsummonbuilding",       itemId = "707016", itemLink = "", name = "Demon Slayer",           desc = "Reach level 60 only by killing demons." },
     GROUNDED               = { id = 4096,  icon = "spell_nature_strengthofearthtotem02", itemId = "707014", itemLink = "", name = "Grounded",               desc = "Reach level 60 without ever using flying services." },
@@ -178,6 +176,7 @@ function WHC.Tab_Achievements(content)
     scrollContent:SetHeight(800)
     scrollFrame:SetScrollChild(scrollContent) -- Attach the content frame to the scroll frame
 
+    WHC.Frames.Achievements = {}
     for i, achievement in ipairs(sortedAchievements) do
         local y = -10 - 53 * (i-1)
 

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -245,7 +245,9 @@ function WHC.Tab_Settings(content)
         WHC_SETTINGS.blockArmorItemsTooltipCheckbox:SetScript("OnClick", function()
             WhcAchievementSettings.blockArmorItemsTooltip = getCheckedValueAndPlaySound(WHC_SETTINGS.blockArmorItemsTooltipCheckbox)
         end)
+    end
 
+    if RETAIL == 0 then
         WHC_SETTINGS.blockNonSelfMadeItemsCheckbox = createSettingsCheckBox(scrollContent, string.format("%s Achievement: Block equipping items you did not craft", WHC.Achievements.SELF_MADE.itemLink))
         WHC_SETTINGS.blockNonSelfMadeItemsCheckbox:SetScript("OnClick", function()
             WhcAchievementSettings.blockNonSelfMadeItems = getCheckedValueAndPlaySound(WHC_SETTINGS.blockNonSelfMadeItemsCheckbox)

--- a/UI.lua
+++ b/UI.lua
@@ -75,7 +75,10 @@ function WHC.UIShowTabContent(tabIndex, arg1)
             WHC_SETTINGS.blockTalentsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTalents))
             WHC_SETTINGS.onlyKillDemonsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillDemons))
             WHC_SETTINGS.onlyKillUndeadCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillUndead))
-            WHC_SETTINGS.onlyKillBoarsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillBoars))
+
+            if RETAIL == 1 or WHC.client.isEnglish then
+                WHC_SETTINGS.onlyKillBoarsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillBoars))
+            end
 
             if RETAIL == 0 then
                 WHC_SETTINGS.blockMagicItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMagicItems))


### PR DESCRIPTION
Refactored death popup logic and only apply it when on the `Permadeath - EU` server

- Renamed `urlFrame` to `appealFrame` as it is for appeals
- Only create the `appealFrame` when on the permadeath server
- Only overwrite the DeathPopup on the permadeath server
- Only listen for Instance events on the permadeath server.

## Refactor
- Moved the `PLAYER_ENTERING_WORLD` logic to the initializetion method. This way we no longer listen to the event on the PTR or the Sanctuary realm, saving resources and memory.

## Bugfix
- No longer throw nil pointer on 1.12 when language isnt english because of missing `onlyKillBoars` checkbox.