### PR TITLE
[Refactor] Dynamic raids clean up + class colors

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -1,8 +1,5 @@
-local addonPrefix = ITEM_QUALITY_COLORS[5].hex.."[WOW-HC.com]: "..FONT_COLOR_CODE_CLOSE
-
 local function achievementErrorMessage(link, message)
-    local achievementMsg = link..HIGHLIGHT_FONT_COLOR_CODE.." Achievement active. "
-    return addonPrefix..achievementMsg..message..FONT_COLOR_CODE_CLOSE
+    return WHC.ADDON_PREFIX..link..HIGHLIGHT_FONT_COLOR_CODE.." Achievement active. " .. message .. FONT_COLOR_CODE_CLOSE
 end
 
 local function printAchievementInfo(link, message)

--- a/Death.lua
+++ b/Death.lua
@@ -95,7 +95,7 @@ local function updateDeathPopupText()
             StaticPopupDialogs["DEATH"].DisplayButton2 = function() return false end
         else
             DEATH_RELEASE = "Go again";
-            StaticPopupDialogs["DEATH"].text = "|cffff0000YOU DIED|r";
+            StaticPopupDialogs["DEATH"].text = WHC.COLORS.RED_FONT_COLOR_CODE .. "YOU DIED" .. FONT_COLOR_CODE_CLOSE;
             StaticPopupDialogs["DEATH"].button1 = "Go again";
             StaticPopupDialogs["DEATH"].button2 = "Appeal";
             StaticPopupDialogs["DEATH"].DisplayButton2 = function() return true end

--- a/Death.lua
+++ b/Death.lua
@@ -95,7 +95,7 @@ local function updateDeathPopupText()
             StaticPopupDialogs["DEATH"].DisplayButton2 = function() return false end
         else
             DEATH_RELEASE = "Go again";
-            StaticPopupDialogs["DEATH"].text = WHC.COLORS.RED_FONT_COLOR_CODE .. "YOU DIED" .. FONT_COLOR_CODE_CLOSE;
+            StaticPopupDialogs["DEATH"].text = RED_FONT_COLOR_CODE .. "YOU DIED" .. FONT_COLOR_CODE_CLOSE;
             StaticPopupDialogs["DEATH"].button1 = "Go again";
             StaticPopupDialogs["DEATH"].button2 = "Appeal";
             StaticPopupDialogs["DEATH"].DisplayButton2 = function() return true end

--- a/Events.lua
+++ b/Events.lua
@@ -321,7 +321,7 @@ local function handleChatEvent(arg1)
         RAID = "Raid " .. HIGHLIGHT_FONT_COLOR_CODE .. "(Normal difficulty)" .. FONT_COLOR_CODE_CLOSE
         raidDifficultyFrame.diff:SetText("Normal")
         if (result == 1) then
-            RAID = "Raid " .. WHC.COLORS.GM_FONT_COLOR_CODE .. "(Dynamic difficulty)" .. FONT_COLOR_CODE_CLOSE
+            RAID = "Raid " .. WHC.COLORS.GM_BLUE_FONT_COLOR_CODE .. "(Dynamic difficulty)" .. FONT_COLOR_CODE_CLOSE
             raidDifficultyFrame.diff:SetText("Dynamic")
         end
 
@@ -334,7 +334,7 @@ local function handleChatEvent(arg1)
 
         RAID = "Raid " .. HIGHLIGHT_FONT_COLOR_CODE .. "(Normal difficulty)" .. FONT_COLOR_CODE_CLOSE
         if (result == 1) then
-            RAID = "Raid " .. WHC.COLORS.GM_FONT_COLOR_CODE .. "(Dynamic difficulty)" .. FONT_COLOR_CODE_CLOSE
+            RAID = "Raid " .. WHC.COLORS.GM_BLUE_FONT_COLOR_CODE .. "(Dynamic difficulty)" .. FONT_COLOR_CODE_CLOSE
         end
 
         return 0

--- a/Events.lua
+++ b/Events.lua
@@ -118,6 +118,120 @@ function MoneyFrame_Update(frameName, money)
     end
 end
 
+local updateAddonFrame
+local function createUpdateAddonFrame()
+    updateAddonFrame = CreateFrame("Frame", "UpdateAddonFrame", UIParent, RETAIL_BACKDROP)
+    updateAddonFrame:SetWidth(300)
+    updateAddonFrame:SetHeight(210)
+    updateAddonFrame:SetPoint("TOP", UIParent, "TOP", 0, -154)
+    updateAddonFrame:SetBackdrop({
+        bgFile = "Interface/RaidFrame/UI-RaidFrame-GroupBg",
+        edgeFile = "Interface/DialogFrame/UI-DialogBox-Border",
+        tile = true,
+        tileSize = 300,
+        edgeSize = 32,
+        insets = { left = 11, right = 12, top = 12, bottom = 11 }
+    })
+
+    updateAddonFrame:SetFrameStrata("HIGH")
+    updateAddonFrame:SetFrameLevel(10)
+
+    -- Title
+    local title = updateAddonFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    title:SetPoint("TOP", updateAddonFrame, "TOP", 0, -20)
+    title:SetText(
+            "|cffff8000WOW-HC addon|r is out of date.\n\nPlease update it to keep things running smoothly.\n\nCopy and paste this URL\ninto your browser:")
+    title:SetWidth(220)
+
+    -- URL input box
+    local updateAddonEditBox = CreateFrame("EditBox", "UpdateAddonInputBox", updateAddonFrame)
+    updateAddonEditBox:SetWidth(250)
+    updateAddonEditBox:SetHeight(20)
+    updateAddonEditBox:SetPoint("TOP", title, "BOTTOM", 0, -20)
+    updateAddonEditBox:SetFontObject("ChatFontNormal")
+    updateAddonEditBox:SetText("https://wow-hc.com/addon")
+    updateAddonEditBox:SetJustifyH("CENTER")
+    updateAddonEditBox:SetAutoFocus(false)
+    updateAddonEditBox:HighlightText()
+    updateAddonEditBox:SetFocus()
+    updateAddonEditBox:SetTextColor(1, 0.631, 0.317)
+    updateAddonEditBox:SetScript("OnMouseDown", function(self)
+        updateAddonEditBox:HighlightText()
+        updateAddonEditBox:SetFocus()
+    end)
+
+    local closeButton = CreateFrame("Button", "CloseButton", updateAddonFrame, "UIPanelButtonGrayTemplate")
+    closeButton:SetWidth(100)
+    closeButton:SetHeight(30)
+    closeButton:SetPoint("BOTTOMLEFT", updateAddonFrame, "BOTTOMLEFT", 100, 24)
+    closeButton:SetText("Close")
+    closeButton:SetScript("OnClick", function()
+        updateAddonFrame:Hide()
+    end)
+
+    updateAddonFrame:Hide()
+end
+
+local raidDifficultyFrame
+local function createRaidDifficultyFrame()
+    raidDifficultyFrame = CreateFrame("Frame", "RaidDifficultyFrame", UIParent, RETAIL_BACKDROP)
+    raidDifficultyFrame:SetWidth(300)
+    raidDifficultyFrame:SetHeight(160)
+    raidDifficultyFrame:SetPoint("TOP", UIParent, "TOP", 0, -154)
+    raidDifficultyFrame:SetBackdrop({
+        bgFile = "Interface/RaidFrame/UI-RaidFrame-GroupBg",
+        edgeFile = "Interface/DialogFrame/UI-DialogBox-Border",
+        tile = true,
+        tileSize = 300,
+        edgeSize = 32,
+        insets = { left = 11, right = 12, top = 12, bottom = 11 }
+    })
+
+    raidDifficultyFrame:SetFrameStrata("HIGH")
+    raidDifficultyFrame:SetFrameLevel(10)
+
+    -- Title
+    local title = raidDifficultyFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    title:SetPoint("TOP", raidDifficultyFrame, "TOP", 0, -20)
+    title:SetText("Current raid difficulty:")
+    title:SetWidth(220)
+
+
+    local desc = raidDifficultyFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    desc:SetPoint("TOP", title, "TOP", 0, -20)
+    desc:SetText("Loading..")
+    desc:SetFont("Fonts\\FRIZQT__.TTF", 18)
+    desc:SetTextColor(0.933, 0.765, 0)
+
+    raidDifficultyFrame.diff = desc;
+
+    local createButton = CreateFrame("Button", "CreateButtonShop", raidDifficultyFrame, "UIPanelButtonTemplate")
+    createButton:SetWidth(130)
+    createButton:SetHeight(35)
+    createButton:SetPoint("TOPLEFT", raidDifficultyFrame, "TOPLEFT", 85, -70)
+    createButton:SetText("SWITCH")
+    createButton:SetScript("OnClick", function()
+        local msg = ".diff"
+        if (RETAIL == 1) then
+            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
+        else
+            SendChatMessage(msg);
+        end
+    end)
+
+    -- Create Close button
+    local closeButton = CreateFrame("Button", "CloseButton", raidDifficultyFrame, "UIPanelButtonGrayTemplate")
+    closeButton:SetWidth(100)
+    closeButton:SetHeight(30)
+    closeButton:SetPoint("TOPLEFT", raidDifficultyFrame, "TOPLEFT", 100, -110)
+    closeButton:SetText("Close")
+    closeButton:SetScript("OnClick", function()
+        raidDifficultyFrame:Hide()
+    end)
+
+    raidDifficultyFrame:Hide()
+end
+
 local function handleChatEvent(arg1)
     local lowerArg = string.lower(arg1)
     if not string.find(lowerArg, "^::whc::") then
@@ -187,150 +301,32 @@ local function handleChatEvent(arg1)
     end
 
     if string.find(lowerArg, "^::whc::outdated:") then
-        if (WHC_ALERT_UPDATE) then
-            WHC_ALERT_UPDATE:Show()
-        else
-            -- Create the URL frame
-            local urlFrame = CreateFrame("Frame", "URLFrameUpdate", UIParent, RETAIL_BACKDROP)
-            urlFrame:SetWidth(300)
-            urlFrame:SetHeight(210)
-            urlFrame:SetPoint("TOP", UIParent, "TOP", 0, -154)
-            urlFrame:SetBackdrop({
-                bgFile = "Interface/RaidFrame/UI-RaidFrame-GroupBg",
-                edgeFile = "Interface/DialogFrame/UI-DialogBox-Border",
-                tile = true,
-                tileSize = 300,
-                edgeSize = 32,
-                insets = { left = 11, right = 12, top = 12, bottom = 11 }
-            })
-
-            urlFrame:SetFrameStrata("HIGH")
-            urlFrame:SetFrameLevel(10)
-
-            -- Title
-            local title = urlFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-            title:SetPoint("TOP", urlFrame, "TOP", 0, -20)
-            title:SetText(
-                "|cffff8000WOW-HC addon|r is out of date.\n\nPlease update it to keep things running smoothly.\n\nCopy and paste this URL\ninto your browser:")
-            title:SetWidth(220)
-
-            -- URL input box
-            local urlEditBox = CreateFrame("EditBox", "URLInputBox", urlFrame)
-            urlEditBox:SetWidth(250)
-            urlEditBox:SetHeight(20)
-            urlEditBox:SetPoint("TOP", title, "BOTTOM", 0, -20)
-            urlEditBox:SetFontObject("ChatFontNormal")
-            urlEditBox:SetText("https://wow-hc.com/addon")
-            urlEditBox:SetJustifyH("CENTER")
-            urlEditBox:SetAutoFocus(false)
-            urlEditBox:HighlightText()
-            urlEditBox:SetFocus()
-            urlEditBox:SetTextColor(1, 0.631, 0.317)
-            urlEditBox:SetScript("OnMouseDown", function(self)
-                urlEditBox:HighlightText()
-                urlEditBox:SetFocus()
-            end)
-
-            local closeButton = CreateFrame("Button", "CloseButton", urlFrame, "UIPanelButtonGrayTemplate")
-            closeButton:SetWidth(100)
-            closeButton:SetHeight(30)
-            closeButton:SetPoint("BOTTOMLEFT", urlFrame, "BOTTOMLEFT", 100, 24)
-            closeButton:SetText("Close")
-            closeButton:SetScript("OnClick", function()
-                WHC_ALERT_UPDATE:Hide()
-            end)
-
-            urlFrame:Show()
-            WHC_ALERT_UPDATE = urlFrame
+        if not updateAddonFrame then
+            createUpdateAddonFrame()
         end
 
+        updateAddonFrame:Show()
         return 0
-        -- message(result)
     end
 
     if string.find(lowerArg, "^::whc::difficulty:lead:") then
         local result = string.gsub(arg1, "::whc::difficulty:lead:", "")
-
         result = tonumber(result)
 
+        if not raidDifficultyFrame then
+            createRaidDifficultyFrame()
+        end
+
+        raidDifficultyFrame:Show()
+
+        RAID = "Raid |cffffffff(Normal difficulty)|r"
+        raidDifficultyFrame.diff:SetText("Normal")
         if (result == 1) then
             RAID = "Raid |cff06daf0(Dynamic difficulty)|r"
-        else
-            RAID = "Raid |cffffffff(Normal difficulty)|r"
+            raidDifficultyFrame.diff:SetText("Dynamic")
         end
 
-        if (WHC_ALERT_DIFF) then
-            WHC_ALERT_DIFF:Show()
-        else
-            -- Create the URL frame
-            local urlFrame = CreateFrame("Frame", "URLFrameDiff", UIParent, RETAIL_BACKDROP)
-            urlFrame:SetWidth(300)
-            urlFrame:SetHeight(160)
-            urlFrame:SetPoint("TOP", UIParent, "TOP", 0, -154)
-            urlFrame:SetBackdrop({
-                bgFile = "Interface/RaidFrame/UI-RaidFrame-GroupBg",
-                edgeFile = "Interface/DialogFrame/UI-DialogBox-Border",
-                tile = true,
-                tileSize = 300,
-                edgeSize = 32,
-                insets = { left = 11, right = 12, top = 12, bottom = 11 }
-            })
-
-            urlFrame:SetFrameStrata("HIGH")
-            urlFrame:SetFrameLevel(10)
-
-            -- Title
-            local title = urlFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-            title:SetPoint("TOP", urlFrame, "TOP", 0, -20)
-            title:SetText(
-                "Current raid difficulty:")
-            title:SetWidth(220)
-
-
-            local desc = urlFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
-            desc:SetPoint("TOP", title, "TOP", 0, -20)
-            desc:SetText("Loading..")
-            desc:SetFont("Fonts\\FRIZQT__.TTF", 18)
-            desc:SetTextColor(0.933, 0.765, 0)
-
-            urlFrame.diff = desc;
-
-
-            local createButton = CreateFrame("Button", "CreateButtonShop", urlFrame, "UIPanelButtonTemplate")
-            createButton:SetWidth(130)
-            createButton:SetHeight(35)
-            createButton:SetPoint("TOPLEFT", urlFrame, "TOPLEFT", 85, -70)
-            createButton:SetText("SWITCH")
-            createButton:SetScript("OnClick", function()
-                local msg = ".diff"
-                if (RETAIL == 1) then
-                    SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-                else
-                    SendChatMessage(msg);
-                end
-            end)
-
-            -- Create Close button
-            local closeButton = CreateFrame("Button", "CloseButton", urlFrame, "UIPanelButtonGrayTemplate")
-            closeButton:SetWidth(100)
-            closeButton:SetHeight(30)
-            closeButton:SetPoint("TOPLEFT", urlFrame, "TOPLEFT", 100, -110)
-            closeButton:SetText("Close")
-            closeButton:SetScript("OnClick", function()
-                WHC_ALERT_DIFF:Hide()
-            end)
-
-            urlFrame:Show()
-            WHC_ALERT_DIFF = urlFrame
-        end
-
-        if (result == 1) then
-            WHC_ALERT_DIFF.diff:SetText("Dynamic")
-        else
-            WHC_ALERT_DIFF.diff:SetText("Normal")
-        end
         return 0
-        -- message(result)
     end
 
     if string.find(lowerArg, "^::whc::difficulty:") then
@@ -373,8 +369,6 @@ if (RETAIL == 1) then
 else
     xx_ChatFrame_OnEvent = ChatFrame_OnEvent
 
-    WHC_ALERT_UPDATE = nil
-    WHC_ALERT_DIFF = nil
     function ChatFrame_OnEvent(event)
         if (event == "CHAT_MSG_RAID_BOSS_EMOTE" or event == "CHAT_MSG_MONSTER_EMOTE") then
             handleMonsterChatEvent(arg1)

--- a/Events.lua
+++ b/Events.lua
@@ -139,8 +139,7 @@ local function createUpdateAddonFrame()
     -- Title
     local title = updateAddonFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     title:SetPoint("TOP", updateAddonFrame, "TOP", 0, -20)
-    title:SetText(
-            "|cffff8000WOW-HC addon|r is out of date.\n\nPlease update it to keep things running smoothly.\n\nCopy and paste this URL\ninto your browser:")
+    title:SetText(WHC.ADDON_PREFIX.."is out of date.\n\nPlease update it to keep things running smoothly.\n\nCopy and paste this URL\ninto your browser:")
     title:SetWidth(220)
 
     -- URL input box
@@ -319,10 +318,10 @@ local function handleChatEvent(arg1)
 
         raidDifficultyFrame:Show()
 
-        RAID = "Raid |cffffffff(Normal difficulty)|r"
+        RAID = "Raid " .. HIGHLIGHT_FONT_COLOR_CODE .. "(Normal difficulty)" .. FONT_COLOR_CODE_CLOSE
         raidDifficultyFrame.diff:SetText("Normal")
         if (result == 1) then
-            RAID = "Raid |cff06daf0(Dynamic difficulty)|r"
+            RAID = "Raid " .. WHC.COLORS.GM_FONT_COLOR_CODE .. "(Dynamic difficulty)" .. FONT_COLOR_CODE_CLOSE
             raidDifficultyFrame.diff:SetText("Dynamic")
         end
 
@@ -331,13 +330,13 @@ local function handleChatEvent(arg1)
 
     if string.find(lowerArg, "^::whc::difficulty:") then
         local result = string.gsub(arg1, "::whc::difficulty:", "")
-
         result = tonumber(result)
+
+        RAID = "Raid " .. HIGHLIGHT_FONT_COLOR_CODE .. "(Normal difficulty)" .. FONT_COLOR_CODE_CLOSE
         if (result == 1) then
-            RAID = "Raid |cff06daf0(Dynamic difficulty)|r"
-        else
-            RAID = "Raid |cffffffff(Normal difficulty)|r"
+            RAID = "Raid " .. WHC.COLORS.GM_FONT_COLOR_CODE .. "(Dynamic difficulty)" .. FONT_COLOR_CODE_CLOSE
         end
+
         return 0
     end
 

--- a/Events.lua
+++ b/Events.lua
@@ -119,7 +119,7 @@ function MoneyFrame_Update(frameName, money)
 end
 
 local updateAddonFrame
-local function createUpdateAddonFrame()
+local function initializeUpdateAddonFrame()
     updateAddonFrame = CreateFrame("Frame", "UpdateAddonFrame", UIParent, RETAIL_BACKDROP)
     updateAddonFrame:SetWidth(300)
     updateAddonFrame:SetHeight(210)
@@ -172,7 +172,7 @@ local function createUpdateAddonFrame()
 end
 
 local raidDifficultyFrame
-local function createRaidDifficultyFrame()
+local function initializeRaidDifficultyFrame()
     raidDifficultyFrame = CreateFrame("Frame", "RaidDifficultyFrame", UIParent, RETAIL_BACKDROP)
     raidDifficultyFrame:SetWidth(300)
     raidDifficultyFrame:SetHeight(160)
@@ -301,7 +301,7 @@ local function handleChatEvent(arg1)
 
     if string.find(lowerArg, "^::whc::outdated:") then
         if not updateAddonFrame then
-            createUpdateAddonFrame()
+            initializeUpdateAddonFrame()
         end
 
         updateAddonFrame:Show()
@@ -313,7 +313,7 @@ local function handleChatEvent(arg1)
         result = tonumber(result)
 
         if not raidDifficultyFrame then
-            createRaidDifficultyFrame()
+            initializeRaidDifficultyFrame()
         end
 
         raidDifficultyFrame:Show()

--- a/Init.lua
+++ b/Init.lua
@@ -31,12 +31,11 @@ WHC.Frames = {
 WHC.COLORS = {
     GM_BLUE_FONT_COLOR_CODE = "|cff06daf0",
     ORANGE_FONT_COLOR_CODE = "|cffe53c15",
-    RED_FONT_COLOR_CODE = RED_FONT_COLOR_CODE or "|cffff2020", -- check if available on 1.12
-    ACHIEVEMENT_COLOR_CODE = ACHIEVEMENT_COLOR_CODE or "|cffffff00", -- check 1.12 but probably isnt ther because achievemnts arent a thing
+    ACHIEVEMENT_COLOR_CODE = ACHIEVEMENT_COLOR_CODE or "|cffffff00", -- Added for 1.12
 }
 
--- TODO test if we can use ITEM_QUALITY_LEGENDARY for number 5
-WHC.ADDON_PREFIX = ITEM_QUALITY_COLORS[5].hex.."[WOW-HC addon]: "..FONT_COLOR_CODE_CLOSE
+local ITEM_QUALITY_LEGENDARY = 5
+WHC.ADDON_PREFIX = ITEM_QUALITY_COLORS[ITEM_QUALITY_LEGENDARY].hex.."[WOW-HC addon]: "..FONT_COLOR_CODE_CLOSE
 
 WHC:RegisterEvent("ADDON_LOADED")
 WHC:SetScript("OnEvent", function(self, event, addonName)
@@ -45,16 +44,6 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
         return
     end
     WHC:UnregisterEvent("ADDON_LOADED")
-
-    WHC.DebugPrint("Poor "..tostring(ITEM_QUALITY_POOR))
-    WHC.DebugPrint("Common "..tostring(ITEM_QUALITY_COMMON))
-    WHC.DebugPrint("Uncommon "..tostring(ITEM_QUALITY_UNCOMMON))
-    WHC.DebugPrint("Rare "..tostring(ITEM_QUALITY_RARE))
-    WHC.DebugPrint("Epic "..tostring(ITEM_QUALITY_EPIC))
-    WHC.DebugPrint("Legendary "..tostring(ITEM_QUALITY_LEGENDARY))
-
-    WHC.DebugPrint("Red Color "..tostring(RED_FONT_COLOR_CODE))
-    WHC.DebugPrint("Achievement Color "..tostring(ACHIEVEMENT_COLOR_CODE))
 
     RETAIL = 1
     local version = GetBuildInfo()

--- a/Init.lua
+++ b/Init.lua
@@ -30,7 +30,7 @@ WHC.Frames = {
 
 WHC.COLORS = {
     GM_BLUE_FONT_COLOR_CODE = "|cff06daf0",
-    ORANGE_FONT_COLOR_CODE = "|cffe53c15",
+    DARK_RED_FONT_COLOR_CODE = "|cffe53c15",
     ACHIEVEMENT_COLOR_CODE = ACHIEVEMENT_COLOR_CODE or "|cffffff00", -- Added for 1.12
 }
 

--- a/Init.lua
+++ b/Init.lua
@@ -28,6 +28,16 @@ WHC.Frames = {
     UIspecialEvent = nil
 }
 
+WHC.COLORS = {
+    GM_BLUE_FONT_COLOR_CODE = "|cff06daf0",
+    ORANGE_FONT_COLOR_CODE = "|cffe53c15",
+    RED_FONT_COLOR_CODE = RED_FONT_COLOR_CODE or "|cffff2020", -- check if available on 1.12
+    ACHIEVEMENT_COLOR_CODE = ACHIEVEMENT_COLOR_CODE or "|cffffff00", -- check 1.12 but probably isnt ther because achievemnts arent a thing
+}
+
+-- TODO test if we can use ITEM_QUALITY_LEGENDARY for number 5
+WHC.ADDON_PREFIX = ITEM_QUALITY_COLORS[5].hex.."[WOW-HC addon]: "..FONT_COLOR_CODE_CLOSE
+
 WHC:RegisterEvent("ADDON_LOADED")
 WHC:SetScript("OnEvent", function(self, event, addonName)
     addonName = addonName or arg1
@@ -35,6 +45,16 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
         return
     end
     WHC:UnregisterEvent("ADDON_LOADED")
+
+    WHC.DebugPrint("Poor "..tostring(ITEM_QUALITY_POOR))
+    WHC.DebugPrint("Common "..tostring(ITEM_QUALITY_COMMON))
+    WHC.DebugPrint("Uncommon "..tostring(ITEM_QUALITY_UNCOMMON))
+    WHC.DebugPrint("Rare "..tostring(ITEM_QUALITY_RARE))
+    WHC.DebugPrint("Epic "..tostring(ITEM_QUALITY_EPIC))
+    WHC.DebugPrint("Legendary "..tostring(ITEM_QUALITY_LEGENDARY))
+
+    WHC.DebugPrint("Red Color "..tostring(RED_FONT_COLOR_CODE))
+    WHC.DebugPrint("Achievement Color "..tostring(ACHIEVEMENT_COLOR_CODE))
 
     RETAIL = 1
     local version = GetBuildInfo()
@@ -224,11 +244,9 @@ function WHC.InitializeDynamicMounts()
 end
 
 function WHC.InitializeTradableRaidLoot()
-    local GM_FONT_COLOR_CODE = "|cff06daf0"
-
     WHC.HookSecureFunc(GameTooltip, "SetBagItem", function(self, container, slot)
         if GameTooltipTextLeft2:GetText() == "Binds when picked up" then
-            local msg = GM_FONT_COLOR_CODE .. "You may trade this item with players who were also eligible to loot it (for a limited time only)" .. FONT_COLOR_CODE_CLOSE
+            local msg = WHC.COLORS.GM_BLUE_FONT_COLOR_CODE .. "You may trade this item with players who were also eligible to loot it (for a limited time only)" .. FONT_COLOR_CODE_CLOSE
             GameTooltip:AddLine(msg, 1, 1, 1, true)
             GameTooltip:Show()
         end

--- a/RecentDeaths.lua
+++ b/RecentDeaths.lua
@@ -98,7 +98,7 @@ local messageRows = {} -- Table to store created font strings
 function WHC.LogDeathMessage(msg)
     if (WhcAddonSettings.recentDeaths == 1) then
         local serverTime = date("%H:%M")
-        local formattedMessage = string.format("|cffFFFF00%s|r %s", serverTime, msg)
+        local formattedMessage = WHC.COLORS.ACHIEVEMENT_COLOR_CODE .. serverTime .. FONT_COLOR_CODE_CLOSE .. " " .. msg
 
         table.insert(deathMessages, 1, formattedMessage) -- Insert at the beginning
 

--- a/Tabs/General.lua
+++ b/Tabs/General.lua
@@ -62,7 +62,7 @@ local tabInfos = {
     { id = 2, icon = "raid",   name = "Dynamic Difficulty", desc = "Raid difficulty can be set to either Normal or Dynamic.\n\nThis setting scales the melee damage, health, mana, and loot of mobs based on the current raid size (with a minimum of 20 players)." },
     { id = 3, icon = "ach",    name = "Achievements",       desc = "Achievements are optional goals that you start with but may lose depending on your actions.\n\nClick on the Achievements tab below to view your character's achievements.\n\nYou can also inspect other players' achievements!" },
     { id = 4, icon = "chrono", name = "Chronoboon",         desc = "Embark on a mysterious cooking quest to upgrade your campfire to a spiritual one.\n\nThis upgrade will allow you to interact with it and suspend your world buffs whenever you wish." },
-    { id = 5, icon = "mag",    name = "Mak'gora",           desc = "Challenge players to a Duel to the Death by typing the |cffffd200.makgora|r command\n\nIf the challenged player accepts, you will fight to the death until only one remains.\n\nFleeing a Mak'gora will result in your immediate execution." },
+    { id = 5, icon = "mag",    name = "Mak'gora",           desc = "Challenge players to a Duel to the Death by typing the "..NORMAL_FONT_COLOR_CODE..".makgora"..FONT_COLOR_CODE_CLOSE.." command\n\nIf the challenged player accepts, you will fight to the death until only one remains.\n\nFleeing a Mak'gora will result in your immediate execution." },
 }
 
 function WHC.Tab_General(content)

--- a/Tabs/Shop.lua
+++ b/Tabs/Shop.lua
@@ -12,7 +12,7 @@ function WHC.Tab_Shop(content)
 
     local desc2 = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     desc2:SetPoint("TOP", desc1, "TOP", 0, -45) -- Adjust y-offset based on logo size
-    desc2:SetText("We do not provide any |cffe53c15Pay-to-Win|r content on this realm.")
+    desc2:SetText("We do not provide any " .. WHC.COLORS.ORANGE_FONT_COLOR_CODE .. "Pay-to-Win" .. FONT_COLOR_CODE_CLOSE .. " content on this realm.")
     desc2:SetWidth(230)
 
 

--- a/Tabs/Shop.lua
+++ b/Tabs/Shop.lua
@@ -12,7 +12,7 @@ function WHC.Tab_Shop(content)
 
     local desc2 = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     desc2:SetPoint("TOP", desc1, "TOP", 0, -45) -- Adjust y-offset based on logo size
-    desc2:SetText("We do not provide any " .. WHC.COLORS.ORANGE_FONT_COLOR_CODE .. "Pay-to-Win" .. FONT_COLOR_CODE_CLOSE .. " content on this realm.")
+    desc2:SetText("We do not provide any " .. WHC.COLORS.DARK_RED_FONT_COLOR_CODE .. "Pay-to-Win" .. FONT_COLOR_CODE_CLOSE .. " content on this realm.")
     desc2:SetWidth(230)
 
 

--- a/UI.lua
+++ b/UI.lua
@@ -12,6 +12,21 @@ function WHC.CheckedValue(value)
     return false
 end
 
+local function getColorCode(colorObject)
+    if not colorObject then return nil end
+
+    -- Scale the 0-1 values to 0-255
+    local r = colorObject.r * 255
+    local g = colorObject.g * 255
+    local b = colorObject.b * 255
+
+    WHC.DebugPrint(string.format("%02x%02x%02x", r, g, b))
+
+    -- Format the numbers into a hex string (e.g., "cff33c9ff")
+    return string.format("|cff%02x%02x%02x", r, g, b)
+end
+
+
 -- Function to show the selected tab's content
 function WHC.UIShowTabContent(tabIndex, arg1)
     if tabIndex == 0 then
@@ -111,7 +126,16 @@ function WHC.UIShowTabContent(tabIndex, arg1)
 
         if (tabIndex == "Achievements") then
             if (arg1 ~= nil) then
-                WHC.Frames.UItab[tabIndex].desc1:SetText("\nListing |cff00C300" .. arg1 .. "|r's achievements")
+                local _, englishClass = UnitClass("arg1")
+                local color = RAID_CLASS_COLORS[englishClass]
+                if englishClass == "SHAMAN" then
+                    color = {r = 0.14, g = 0.35, b = 1} -- TBC Shaman color
+                end
+
+                local classColorCode = getColorCode(color)
+
+                local player = classColorCode .. arg1 .. FONT_COLOR_CODE_CLOSE
+                WHC.Frames.UItab[tabIndex].desc1:SetText("\nListing " .. player .. "'s achievements")
             else
                 WHC.Frames.UItab[tabIndex].desc1:SetText(
                     "Achievements are optional goals that you start with but may lose depending on your actions")

--- a/UI.lua
+++ b/UI.lua
@@ -13,17 +13,19 @@ function WHC.CheckedValue(value)
 end
 
 local function getColorCode(colorObject)
-    if not colorObject then return nil end
+    local colorStr = colorObject.colorStr
 
-    -- Scale the 0-1 values to 0-255
-    local r = colorObject.r * 255
-    local g = colorObject.g * 255
-    local b = colorObject.b * 255
+    if not colorStr then
+        -- Scale the 0-1 values to 0-255
+        local r = colorObject.r * 255
+        local g = colorObject.g * 255
+        local b = colorObject.b * 255
 
-    WHC.DebugPrint(string.format("%02x%02x%02x", r, g, b))
+        -- Format the numbers into a hex string (e.g., "ff33c9ff")
+        colorStr = string.format("ff%02x%02x%02x", r, g, b)
+    end
 
-    -- Format the numbers into a hex string (e.g., "cff33c9ff")
-    return string.format("|cff%02x%02x%02x", r, g, b)
+    return string.format("|c%s", colorStr)
 end
 
 
@@ -93,7 +95,7 @@ function WHC.UIShowTabContent(tabIndex, arg1)
         WHC_SETTINGS.onlyKillDemonsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillDemons))
         WHC_SETTINGS.onlyKillUndeadCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillUndead))
 
-		if RETAIL == 1 or WHC.client.isEnglish then
+        if RETAIL == 1 or WHC.client.isEnglish then
             WHC_SETTINGS.onlyKillBoarsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillBoars))
         end
 
@@ -126,15 +128,16 @@ function WHC.UIShowTabContent(tabIndex, arg1)
 
         if (tabIndex == "Achievements") then
             if (arg1 ~= nil) then
-                local _, englishClass = UnitClass("arg1")
+                local name = UnitName("target")
+                local _, englishClass = UnitClass("target")
+
                 local color = RAID_CLASS_COLORS[englishClass]
                 if englishClass == "SHAMAN" then
-                    color = {r = 0.14, g = 0.35, b = 1} -- TBC Shaman color
+                    color = {r = 0.14, g = 0.35, b = 1, colorStr = "ff2459ff"} -- TBC Shaman color
                 end
 
                 local classColorCode = getColorCode(color)
-
-                local player = classColorCode .. arg1 .. FONT_COLOR_CODE_CLOSE
+                local player = classColorCode .. name .. FONT_COLOR_CODE_CLOSE
                 WHC.Frames.UItab[tabIndex].desc1:SetText("\nListing " .. player .. "'s achievements")
             else
                 WHC.Frames.UItab[tabIndex].desc1:SetText(

--- a/UI.lua
+++ b/UI.lua
@@ -294,8 +294,9 @@ function WHC.InitializeUI()
     SlashCmdList["WOWHC"] = function(msg)
         if WHC:IsVisible() then
             WHC:Hide()
-        else
-            WHC.UIShowTabContent("General") -- Initialize with the first tab visible
+            return
         end
+
+        WHC.UIShowTabContent("General") -- Initialize with the first tab visible
     end
 end

--- a/UI.lua
+++ b/UI.lua
@@ -16,101 +16,102 @@ end
 function WHC.UIShowTabContent(tabIndex, arg1)
     if tabIndex == 0 then
         WHC:Hide()
-    else
-        WHC:Show()
-        -- Hide all tab contents first
+        return
+    end
 
-        if (tabIndex == "Support") then
-            WHC.Frames.UItab["Support"].editBox:SetText("")
-            WHC.Frames.UItab["Support"].createButton:SetText("Create ticket")
-            WHC.Frames.UItab["Support"].closeButton:SetText("Close")
-            local msg = ".whc ticketget"
-            if (RETAIL == 1) then
-                SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-            else
-                SendChatMessage(msg);
-            end
-        elseif (tabIndex == "Achievements") then
-            for key, value in pairs(WHC.Frames.Achievements) do
-                WHC.ToggleAchievement(value, true)
-            end
-
-            local msg = ".whc achievements"
-            if (arg1 == 1) then
-                msg = msg .. " target"
-            end
-
-            if (RETAIL == 1) then
-                SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-            else
-                SendChatMessage(msg);
-            end
-        elseif (tabIndex == "PVP") then
-            if (WHC.Frames.UIspecialEvent ~= nil) then
-                WHC.Frames.UIspecialEvent:SetButtonState("DISABLED")
-            end
-
-
-            local msg = ".whc event"
-            if (RETAIL == 1) then
-                SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-            else
-                SendChatMessage(msg);
-            end
-        elseif (tabIndex == "Settings") then
-            WHC_SETTINGS.minimap:SetChecked(WHC.CheckedValue(WhcAddonSettings.minimapicon))
-            WHC_SETTINGS.achievementbtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.achievementbtn))
-            WHC_SETTINGS.recentDeathsBtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.recentDeaths))
-
-            WHC_SETTINGS.blockInvitesCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockInvites))
-            WHC_SETTINGS.blockTradesCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTrades))
-            WHC_SETTINGS.blockAuctionSellCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockAuctionSell))
-            WHC_SETTINGS.blockAuctionBuyCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockAuctionBuy))
-            WHC_SETTINGS.blockRepairCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRepair))
-            WHC_SETTINGS.blockTaxiServiceCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTaxiService))
-            WHC_SETTINGS.blockMailItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMailItems))
-            WHC_SETTINGS.blockRidingSkillCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRidingSkill))
-            WHC_SETTINGS.blockProfessionsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockProfessions))
-            WHC_SETTINGS.blockQuestsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockQuests))
-            WHC_SETTINGS.blockTalentsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTalents))
-            WHC_SETTINGS.onlyKillDemonsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillDemons))
-            WHC_SETTINGS.onlyKillUndeadCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillUndead))
-            WHC_SETTINGS.onlyKillBoarsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillBoars))
-
-            if RETAIL == 0 then
-                WHC_SETTINGS.blockMagicItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMagicItems))
-                WHC_SETTINGS.blockMagicItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMagicItemsTooltip))
-                WHC_SETTINGS.blockArmorItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockArmorItems))
-                WHC_SETTINGS.blockArmorItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockArmorItemsTooltip))
-                WHC_SETTINGS.blockNonSelfMadeItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockNonSelfMadeItems))
-                WHC_SETTINGS.blockNonSelfMadeItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockNonSelfMadeItemsTooltip))
-            end
-        elseif (tabIndex == "General") then
-            --
+    WHC:Show()
+    if (tabIndex == "General") then
+        --
+    elseif (tabIndex == "Achievements") then
+        for key, value in pairs(WHC.Frames.Achievements) do
+            WHC.ToggleAchievement(value, true)
         end
 
-        for index, value in ipairs(tabKeys) do
-            if WHC.Frames.UItab[value] then
-                WHC.Frames.UItab[value]:Hide()
-                WHC.Frames.UItabHeader[value]:SetNormalTexture("Interface/PaperDollInfoFrame/UI-Character-InActiveTab")
-                WHC.Frames.UItabHeader[value].tabText:SetTextColor(0.933, 0.765, 0)
-                WHC.Frames.UItabHeader[value]:Enable()
-            end
+        local msg = ".whc achievements"
+        if (arg1 == 1) then
+            msg = msg .. " target"
         end
 
-        if WHC.Frames.UItab[tabIndex] then
-            WHC.Frames.UItab[tabIndex]:Show()
-            WHC.Frames.UItabHeader[tabIndex]:SetNormalTexture("Interface/PaperDollInfoFrame/UI-Character-ActiveTab")
-            WHC.Frames.UItabHeader[tabIndex].tabText:SetTextColor(1, 1, 1)
-            WHC.Frames.UItabHeader[tabIndex]:Disable()
+        if (RETAIL == 1) then
+            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
+        else
+            SendChatMessage(msg);
+        end
+    elseif (tabIndex == "PVP") then
+        if (WHC.Frames.UIspecialEvent ~= nil) then
+            WHC.Frames.UIspecialEvent:SetButtonState("DISABLED")
+        end
 
-            if (tabIndex == "Achievements") then
-                if (arg1 ~= nil) then
-                    WHC.Frames.UItab[tabIndex].desc1:SetText("\nListing |cff00C300" .. arg1 .. "|r's achievements")
-                else
-                    WHC.Frames.UItab[tabIndex].desc1:SetText(
-                        "Achievements are optional goals that you start with but may lose depending on your actions")
-                end
+
+        local msg = ".whc event"
+        if (RETAIL == 1) then
+            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
+        else
+            SendChatMessage(msg);
+        end
+    elseif (tabIndex == "Support") then
+        WHC.Frames.UItab["Support"].editBox:SetText("")
+        WHC.Frames.UItab["Support"].createButton:SetText("Create ticket")
+        WHC.Frames.UItab["Support"].closeButton:SetText("Close")
+        local msg = ".whc ticketget"
+        if (RETAIL == 1) then
+            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
+        else
+            SendChatMessage(msg);
+        end
+    elseif (tabIndex == "Settings") then
+        WHC_SETTINGS.minimap:SetChecked(WHC.CheckedValue(WhcAddonSettings.minimapicon))
+        WHC_SETTINGS.achievementbtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.achievementbtn))
+        WHC_SETTINGS.recentDeathsBtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.recentDeaths))
+
+        WHC_SETTINGS.blockInvitesCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockInvites))
+        WHC_SETTINGS.blockTradesCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTrades))
+        WHC_SETTINGS.blockAuctionSellCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockAuctionSell))
+        WHC_SETTINGS.blockAuctionBuyCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockAuctionBuy))
+        WHC_SETTINGS.blockRepairCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRepair))
+        WHC_SETTINGS.blockTaxiServiceCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTaxiService))
+        WHC_SETTINGS.blockMailItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMailItems))
+        WHC_SETTINGS.blockRidingSkillCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRidingSkill))
+        WHC_SETTINGS.blockProfessionsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockProfessions))
+        WHC_SETTINGS.blockQuestsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockQuests))
+        WHC_SETTINGS.blockTalentsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockTalents))
+        WHC_SETTINGS.onlyKillDemonsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillDemons))
+        WHC_SETTINGS.onlyKillUndeadCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillUndead))
+        WHC_SETTINGS.onlyKillBoarsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.onlyKillBoars))
+
+        if RETAIL == 0 then
+            WHC_SETTINGS.blockMagicItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMagicItems))
+            WHC_SETTINGS.blockMagicItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockMagicItemsTooltip))
+            WHC_SETTINGS.blockArmorItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockArmorItems))
+            WHC_SETTINGS.blockArmorItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockArmorItemsTooltip))
+            WHC_SETTINGS.blockNonSelfMadeItemsCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockNonSelfMadeItems))
+            WHC_SETTINGS.blockNonSelfMadeItemsTooltipCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockNonSelfMadeItemsTooltip))
+        end
+    end
+
+    -- Hide all tab contents first
+    for index, value in ipairs(tabKeys) do
+        if WHC.Frames.UItab[value] then
+            WHC.Frames.UItab[value]:Hide()
+            WHC.Frames.UItabHeader[value]:SetNormalTexture("Interface/PaperDollInfoFrame/UI-Character-InActiveTab")
+            WHC.Frames.UItabHeader[value].tabText:SetTextColor(0.933, 0.765, 0)
+            WHC.Frames.UItabHeader[value]:Enable()
+        end
+    end
+
+    -- Show relevant tab
+    if WHC.Frames.UItab[tabIndex] then
+        WHC.Frames.UItab[tabIndex]:Show()
+        WHC.Frames.UItabHeader[tabIndex]:SetNormalTexture("Interface/PaperDollInfoFrame/UI-Character-ActiveTab")
+        WHC.Frames.UItabHeader[tabIndex].tabText:SetTextColor(1, 1, 1)
+        WHC.Frames.UItabHeader[tabIndex]:Disable()
+
+        if (tabIndex == "Achievements") then
+            if (arg1 ~= nil) then
+                WHC.Frames.UItab[tabIndex].desc1:SetText("\nListing |cff00C300" .. arg1 .. "|r's achievements")
+            else
+                WHC.Frames.UItab[tabIndex].desc1:SetText(
+                    "Achievements are optional goals that you start with but may lose depending on your actions")
             end
         end
     end
@@ -264,7 +265,6 @@ function WHC.InitializeUI()
         if WHC:IsVisible() then
             WHC:Hide()
         else
-            WHC:Show()
             WHC.UIShowTabContent("General") -- Initialize with the first tab visible
         end
     end


### PR DESCRIPTION
## Refactor
- Removed `WHC_ALERT_UPDATE` from the global scope
- Removed `WHC_ALERT_DIFF` from the global scope
- Added function for creating the `UpdateAddonFrame` and `RaidDiffucultyFrame` to make clear separation of concerns
- Removed unnecessary if statement for raid difficulty
- Removed all "magic string" color codes and used either officially available color codes or added them with a defined name to `WHC.COLORS`
- Reordered the if statements of `UIShowTabContent()` to have the same order as elements are shown in game

## Change
- Change the greenish color used for the player name when inspecting other players achievements and instead used the official class color.
- Overwrite the pink shaman color and instead uses the TBC shaman color. 
  - **Note** This is a change from how the default client, both 1.12 and 1.14, display shamans as Pink. Some addons like `ShaguTweaks` has an option to swap to the TBC shaman color by overwriting the `RAID_CLASS_COLORS["SHAMAN"]` entry, effectively making it appear with TBC colors in all other addons and in game. I would like to get your take on if you think this is a good change or if we should keep it default and let players decide their shaman color via addons.