### PR TITLE
[Bugfix] Correctly show achievement links on 1.14

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -315,19 +315,6 @@ local selfMadeAllowedItems = {
     ["釣魚竿"] = true,          -- Chinese (Traditional)
 }
 
-local function getItemIDFromLink(itemLink)
-    if not itemLink then
-        return
-    end
-
-    local foundID, _ , itemID = string.find(itemLink, "item:(%d+)")
-    if not foundID then
-        return
-    end
-
-    return tonumber(itemID)
-end
-
 -- TODO Make this more robust
 -- The <Made by xxx> is localized.
 -- This pattern works for English, German, French, Spanish, Portuguese, Italian, Russian
@@ -365,7 +352,7 @@ local function getItemInfo(itemId)
 end
 
 local function setTooltipInfo(itemLink)
-    local itemId = getItemIDFromLink(itemLink)
+    local itemId = WHC.GetItemIDFromLink(itemLink)
     local itemRarity, itemSubType, itemEquipLoc = getItemInfo(itemId)
 
     if not itemEquipLoc or itemEquipLoc == "" then
@@ -400,7 +387,7 @@ WHC.HookSecureFunc(GameTooltip, "SetInventoryItem", function(tip, unit, slot)
     local itemLink = GetInventoryItemLink(unit, slot)
     -- Inventory slots
     if slot < 20 then
-        local itemId = getItemIDFromLink(itemLink)
+        local itemId = WHC.GetItemIDFromLink(itemLink)
         local itemRarity, itemSubType, itemEquipLoc = getItemInfo(itemId)
         if not itemEquipLoc or itemEquipLoc == "" then
             return
@@ -445,7 +432,7 @@ local equipErrorMessages = {}
 local function canEquipItem(itemLink)
     equipErrorMessages = {}
 
-    local itemId = getItemIDFromLink(itemLink)
+    local itemId = WHC.GetItemIDFromLink(itemLink)
     local itemRarity, itemSubType, itemEquipLoc = getItemInfo(itemId)
     if not itemEquipLoc or itemEquipLoc == "" or itemEquipLoc == "INVTYPE_BAG" then
         return
@@ -524,7 +511,7 @@ function WHC.SetBlockEquipItems()
         -- When the user tries to equip the item from the backpack, then we can validate with CursorHasItem()
         PickupMerchantItem = function(index)
             local itemLink = GetMerchantItemLink(index)
-            local itemId = getItemIDFromLink(itemLink)
+            local itemId = WHC.GetItemIDFromLink(itemLink)
             local itemRarity, itemSubType, itemEquipLoc = getItemInfo(itemId)
             if not itemEquipLoc or itemEquipLoc == "" or itemEquipLoc == "INVTYPE_BAG" then
                 return BlizzardFunctions.PickupMerchantItem(index)
@@ -614,7 +601,7 @@ local isMailAllowed = function(index, itemIndex)
     -- Making a copy of a mail works as normal
     if GetInboxItemLink and itemIndex then
         local itemLink = GetInboxItemLink(index, itemIndex)
-        local itemId = getItemIDFromLink(itemLink)
+        local itemId = WHC.GetItemIDFromLink(itemLink)
         return 8383 == itemId -- Plain Letter
     end
 

--- a/Init.lua
+++ b/Init.lua
@@ -34,8 +34,17 @@ WHC.COLORS = {
     ACHIEVEMENT_COLOR_CODE = ACHIEVEMENT_COLOR_CODE or "|cffffff00", -- Added for 1.12
 }
 
-local ITEM_QUALITY_LEGENDARY = 5
-WHC.ADDON_PREFIX = ITEM_QUALITY_COLORS[ITEM_QUALITY_LEGENDARY].hex.."[WOW-HC addon]: "..FONT_COLOR_CODE_CLOSE
+WHC.ITEM_QUALITY = {
+    POOR = 0,      -- Gray
+    COMMON = 1,    -- White
+    UNCOMMON = 2,  -- Green
+    RARE = 3,      -- Blue
+    EPIC = 4,      -- Purple
+    LEGENDARY = 5, -- Orange
+    ARTIFACT = 6,  -- Light Gold
+}
+
+WHC.ADDON_PREFIX = ITEM_QUALITY_COLORS[WHC.ITEM_QUALITY.LEGENDARY].hex.."[WOW-HC addon]: "..FONT_COLOR_CODE_CLOSE
 
 WHC:RegisterEvent("ADDON_LOADED")
 WHC:SetScript("OnEvent", function(self, event, addonName)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 - Pressing ESC now closes the addon
 - Added sounds for opening and closing the addon, as well as selecting tabs
 - Opens the Addon ticket system when right-clicking a player to report them
-- Store bought dynamic speed mounts now show their current speed on the buff tooltip 
+- Store bought dynamic speed mounts now show their current speed on the buff tooltip
+- Fixed achievement links now showing anything on 1.14
 
 ## Future versions:
 - Prevent/disable auto-run when you are on a flypath
@@ -24,7 +25,6 @@
 - proper custom titles (may need client mods, needs more researches)
 - when achievement failed, display custom box similar to wotlk achievements
 - fix 1.14 elevators sync by sending a packet when near (needs more researches)
-- fix 1.14 custom item display "?" (needs more researches, see _Potentialfix_questin_mark.lua)
 - fix 1.14 missing packet on jump while MCing (razor for example, needs more researches)
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - Added sounds for opening and closing the addon, as well as selecting tabs
 - Opens the Addon ticket system when right-clicking a player to report them
 - Store bought dynamic speed mounts now show their current speed on the buff tooltip
-- Fixed achievement links now showing anything on 1.14
+- Fixed achievement links not showing anything on 1.14
 
 ## Future versions:
 - Prevent/disable auto-run when you are on a flypath

--- a/Tabs/Achievements.lua
+++ b/Tabs/Achievements.lua
@@ -131,13 +131,31 @@ local function achievementLink(achievement)
 end
 
 local sortedAchievements = {}
+local achievementsItemIDTable = {}
 for key, value in pairs(WHC.Achievements) do
     value.itemLink = achievementLink(value)
     table.insert(sortedAchievements, value)
+    achievementsItemIDTable[tonumber(value.itemId)] = value
 end
 table.sort(sortedAchievements, function(a, b)
     return a.name < b.name  -- Sort alphabetically by name
 end)
+
+local function initializeAchievementItemLinks()
+    WHC.HookSecureFunc("ChatFrame_OnHyperlinkShow", function(chatFrame, linkData, link, button)
+        local itemID = WHC.GetItemIDFromLink(linkData)
+        local achievement = achievementsItemIDTable[itemID]
+        local itemName = GetItemInfo(itemID)
+        if achievement and not itemName then
+            local titleColor = ITEM_QUALITY_COLORS[WHC.ITEM_QUALITY.LEGENDARY]
+            ItemRefTooltipTextLeft1:SetText(achievement.name)
+            ItemRefTooltipTextLeft1:SetTextColor(titleColor.r, titleColor.g, titleColor.b)
+            local descColor = ITEM_QUALITY_COLORS[WHC.ITEM_QUALITY.ARTIFACT]
+            ItemRefTooltip:AddLine(string.format("\"%s\"", achievement.desc), descColor.r, descColor.g, descColor.b, true)
+            ItemRefTooltip:Show()
+        end
+    end)
+end
 
 function WHC.Tab_Achievements(content)
     local title = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
@@ -190,6 +208,9 @@ function WHC.Tab_Achievements(content)
     desc2:SetWidth(450)
     desc2:SetFont("Fonts\\FRIZQT__.TTF", 10)
 
+    if RETAIL == 1 then
+        initializeAchievementItemLinks()
+    end
 
     return content;
 end

--- a/UI.lua
+++ b/UI.lua
@@ -199,35 +199,29 @@ function WHC.InitializeUI()
     local widthTotal = 0
     for index, value in ipairs(tabKeys) do
         local tabHeader = CreateFrame("Button", "TabHeader" .. value, tabContainer)
+        tabHeader:SetHeight(30)
 
         local width = 0
         if value == "General" then
             tabHeader:SetWidth(90)
-            tabHeader:SetHeight(30)
             width = 91
         elseif value == "Achievements" then
             tabHeader:SetWidth(130)
-            tabHeader:SetHeight(30)
             width = 119
         elseif value == "PVP" then
             tabHeader:SetWidth(70)
-            tabHeader:SetHeight(30)
             width = 64
         elseif value == "Shop" then
             tabHeader:SetWidth(70)
-            tabHeader:SetHeight(30)
             width = 62
         elseif value == "Support" then
             tabHeader:SetWidth(84)
-            tabHeader:SetHeight(30)
             width = 76
         elseif value == "Settings" then
             tabHeader:SetWidth(86)
-            tabHeader:SetHeight(30)
             width = 0
         else
             tabHeader:SetWidth(120)
-            tabHeader:SetHeight(30)
             width = 90
         end
 
@@ -255,14 +249,12 @@ function WHC.InitializeUI()
 
         WHC.Frames.UItabHeader[value] = tabHeader
 
-
         -- TABS Content
         local content = CreateFrame("Frame", "Tab" .. value .. "Content", WHC)
         content:SetWidth(500)
         content:SetHeight(440)
         content:SetPoint("TOPLEFT", WHC, "TOPLEFT", 0, -40)
         content:Hide()
-
 
         if value == "Achievements" then
             content = WHC.Tab_Achievements(content)

--- a/Util.lua
+++ b/Util.lua
@@ -18,6 +18,19 @@ function WHC.HookSecureFunc(arg1, arg2, arg3)
     end
 end
 
+function WHC.GetItemIDFromLink(itemLink)
+    if not itemLink then
+        return
+    end
+
+    local foundID, _ , itemID = string.find(itemLink, "item:(%d+)")
+    if not foundID then
+        return
+    end
+
+    return tonumber(itemID)
+end
+
 -- Function to print debug messages
 function WHC.DebugPrint(message)
     DEFAULT_CHAT_FRAME:AddMessage(tostring(message))


### PR DESCRIPTION
## Change
- Added logic for showing achievement links when not accessible from the server on 1.14.

**Before**: The default logic was as follow: Links works as normal when the achievement item has been seen, i.e. given to a player in their bag with `.additem`. When the item has not been seen, it show the red "Retrieving information from server"

**After**: If no information is found on the item with `GetItemInfo()` then we set the information ourselves.

## Refactor
- Made `GetItemIDFromLink()` global function on the `WHC` frame