### PR TITLE
[Refactor] Cleanup commands

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -14,11 +14,7 @@ playerLogin:SetScript("OnEvent", function(self, event)
     end
 
     local msg = ".whc version " .. GetAddOnMetadata("WOW_HC", "Version")
-    if (RETAIL == 1) then
-        SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-    else
-        SendChatMessage(msg);
-    end
+    SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
 end)
 
 local function createAchievementButton(frame, name)
@@ -211,11 +207,7 @@ local function initializeRaidDifficultyFrame()
     createButton:SetText("SWITCH")
     createButton:SetScript("OnClick", function()
         local msg = ".diff"
-        if (RETAIL == 1) then
-            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        else
-            SendChatMessage(msg);
-        end
+        SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
     end)
 
     -- Create Close button
@@ -245,21 +237,16 @@ local function handleChatEvent(arg1)
         WHC.Frames.UItab["Support"].closeButton:SetText("Cancel ticket")
 
         return 0
-        -- message(result)
     end
 
     if string.find(lowerArg, "^::whc::achievement:") then
         local result = string.gsub(arg1, "::whc::achievement:", "")
-
         result = tonumber(result)
         if (WHC.Frames.Achievements[result]) then
             WHC.ToggleAchievement(WHC.Frames.Achievements[result], false)
-        else
-            -- message("error")
         end
 
         return 0
-        -- message(result)
     end
 
     if string.find(lowerArg, "^::whc::auction:") then
@@ -290,11 +277,7 @@ local function handleChatEvent(arg1)
 
     if string.find(lowerArg, "^::whc::debug:") then
         local result = string.gsub(arg1, "::whc::debug:", "")
-        if (RETAIL == 1) then
-            SendChatMessage(result, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        else
-            SendChatMessage(result);
-        end
+        SendChatMessage(result, "WHISPER", GetDefaultLanguage(), UnitName("player"));
 
         return 0
     end

--- a/Init.lua
+++ b/Init.lua
@@ -139,13 +139,6 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
         WHC.InitializeDeathPopupAppeal()
     end
 
-    local msg = ".whc version " .. GetAddOnMetadata("WOW_HC", "Version")
-    if (RETAIL == 1) then
-        SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-    else
-        SendChatMessage(msg);
-    end
-
     if (WhcAddonSettings.splash == 0) then
         WhcAddonSettings.splash = 1
 

--- a/Support.lua
+++ b/Support.lua
@@ -19,7 +19,8 @@ function WHC.InitializeSupport()
         end
 
         StaticPopupDialogs["HELP_TICKET"].OnCancel = function()
-            WHC.UIShowTabContent(supportTabIndex)
+            local msg = ".whc ticketdelete"
+            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
         end
     end
 

--- a/Tabs/PVP.lua
+++ b/Tabs/PVP.lua
@@ -122,12 +122,7 @@ local function bgSlot(content, index, icon, label, desc)
     createButton:SetText("JOIN")
     createButton:SetScript("OnClick", function()
         local msg = "." .. icon
-
-        if (RETAIL == 1) then
-            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        else
-            SendChatMessage(msg);
-        end
+        SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
     end)
 
     if (index == 3) then

--- a/Tabs/Support.lua
+++ b/Tabs/Support.lua
@@ -24,8 +24,6 @@ function WHC.Tab_Support(content)
         "All other issues should be reported through our forums [wow-hc.com]")
     desc2:SetWidth(260)
 
-
-
     local label = content:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
     label:SetPoint("TOP", desc2, "TOP", 0, -60) -- Adjust y-offset based on logo size
     label:SetText(
@@ -65,25 +63,10 @@ function WHC.Tab_Support(content)
     createButton:SetText("Create ticket")
     createButton:SetScript("OnClick", function()
         local issue = editBox:GetText()
-
-
-        if issue == "" then
-            message("Please describe your issue")
-            -- StaticPopupDialogs["ERROR_DIALOG"] = {
-            --     text = "Please describe your issue",
-            --     button1 = "OK",
-            --     timeout = 0,
-            --     whileDead = true,
-            --     hideOnEscape = true
-            -- }
-            -- StaticPopup_Show("ERROR_DIALOG")
-        else
+        if issue ~= "" then
             local msg = ".whc ticketcreate " .. issue
-        if (RETAIL == 1) then
             SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        else
-            SendChatMessage(msg);
-        end
+
             WHC.UIShowTabContent(0)
         end
     end)
@@ -99,13 +82,9 @@ function WHC.Tab_Support(content)
     closeButton:SetText("Close")
     closeButton:SetScript("OnClick", function()
         local msg = ".whc ticketdelete"
-        if (RETAIL == 1) then
-            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        else
-            SendChatMessage(msg);
-        end
-        WHC.UIShowTabContent(0)
+        SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
 
+        WHC.UIShowTabContent(0)
     end)
     content.closeButton = closeButton;
 

--- a/UI.lua
+++ b/UI.lua
@@ -28,6 +28,19 @@ local function getColorCode(colorObject)
     return string.format("|c%s", colorStr)
 end
 
+local function getTargetAchievementsDescription()
+    local name = UnitName("target")
+    local _, englishClass = UnitClass("target")
+
+    local color = RAID_CLASS_COLORS[englishClass]
+    if englishClass == "SHAMAN" then
+        color = {r = 0.14, g = 0.35, b = 1, colorStr = "ff2459ff"} -- TBC Shaman color
+    end
+
+    local classColorCode = getColorCode(color)
+    local player = classColorCode .. name .. FONT_COLOR_CODE_CLOSE
+    return "\nListing " .. player .. "'s achievements"
+end
 
 -- Function to show the selected tab's content
 function WHC.UIShowTabContent(tabIndex, arg1)
@@ -40,15 +53,21 @@ function WHC.UIShowTabContent(tabIndex, arg1)
     if (tabIndex == "General") then
         --
     elseif (tabIndex == "Achievements") then
+        local msg = ".whc achievements"
+        local desc = "Achievements are optional goals that you start with but may lose depending on your actions"
+        if (arg1 ~= nil) then
+            msg = msg .. " target"
+            desc = getTargetAchievementsDescription()
+        end
+
+        WHC.Frames.UItab[tabIndex].desc1:SetText(desc)
+
+        -- Set all achievements as failed
         for key, value in pairs(WHC.Frames.Achievements) do
             WHC.ToggleAchievement(value, true)
         end
 
-        local msg = ".whc achievements"
-        if (arg1 == 1) then
-            msg = msg .. " target"
-        end
-
+        -- Update achievement status from server
         SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
     elseif (tabIndex == "PVP") then
         if (WHC.Frames.UIspecialEvent ~= nil) then
@@ -58,9 +77,9 @@ function WHC.UIShowTabContent(tabIndex, arg1)
         local msg = ".whc event"
         SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
     elseif (tabIndex == "Support") then
-        WHC.Frames.UItab["Support"].editBox:SetText("")
-        WHC.Frames.UItab["Support"].createButton:SetText("Create ticket")
-        WHC.Frames.UItab["Support"].closeButton:SetText("Close")
+        WHC.Frames.UItab[tabIndex].editBox:SetText("")
+        WHC.Frames.UItab[tabIndex].createButton:SetText("Create ticket")
+        WHC.Frames.UItab[tabIndex].closeButton:SetText("Close")
 
         local msg = ".whc ticketget"
         SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
@@ -113,25 +132,6 @@ function WHC.UIShowTabContent(tabIndex, arg1)
         WHC.Frames.UItabHeader[tabIndex]:SetNormalTexture("Interface/PaperDollInfoFrame/UI-Character-ActiveTab")
         WHC.Frames.UItabHeader[tabIndex].tabText:SetTextColor(1, 1, 1)
         WHC.Frames.UItabHeader[tabIndex]:Disable()
-
-        if (tabIndex == "Achievements") then
-            WHC.Frames.UItab[tabIndex].desc1:SetText(
-                    "Achievements are optional goals that you start with but may lose depending on your actions")
-
-            if (arg1 ~= nil) then
-                local name = UnitName("target")
-                local _, englishClass = UnitClass("target")
-
-                local color = RAID_CLASS_COLORS[englishClass]
-                if englishClass == "SHAMAN" then
-                    color = {r = 0.14, g = 0.35, b = 1, colorStr = "ff2459ff"} -- TBC Shaman color
-                end
-
-                local classColorCode = getColorCode(color)
-                local player = classColorCode .. name .. FONT_COLOR_CODE_CLOSE
-                WHC.Frames.UItab[tabIndex].desc1:SetText("\nListing " .. player .. "'s achievements")
-            end
-        end
     end
 end
 

--- a/UI.lua
+++ b/UI.lua
@@ -49,33 +49,21 @@ function WHC.UIShowTabContent(tabIndex, arg1)
             msg = msg .. " target"
         end
 
-        if (RETAIL == 1) then
-            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        else
-            SendChatMessage(msg);
-        end
+        SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
     elseif (tabIndex == "PVP") then
         if (WHC.Frames.UIspecialEvent ~= nil) then
             WHC.Frames.UIspecialEvent:SetButtonState("DISABLED")
         end
 
-
         local msg = ".whc event"
-        if (RETAIL == 1) then
-            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        else
-            SendChatMessage(msg);
-        end
+        SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
     elseif (tabIndex == "Support") then
         WHC.Frames.UItab["Support"].editBox:SetText("")
         WHC.Frames.UItab["Support"].createButton:SetText("Create ticket")
         WHC.Frames.UItab["Support"].closeButton:SetText("Close")
+
         local msg = ".whc ticketget"
-        if (RETAIL == 1) then
-            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        else
-            SendChatMessage(msg);
-        end
+        SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
     elseif (tabIndex == "Settings") then
         WHC_SETTINGS.minimap:SetChecked(WHC.CheckedValue(WhcAddonSettings.minimapicon))
         WHC_SETTINGS.achievementbtn:SetChecked(WHC.CheckedValue(WhcAddonSettings.achievementbtn))
@@ -127,6 +115,9 @@ function WHC.UIShowTabContent(tabIndex, arg1)
         WHC.Frames.UItabHeader[tabIndex]:Disable()
 
         if (tabIndex == "Achievements") then
+            WHC.Frames.UItab[tabIndex].desc1:SetText(
+                    "Achievements are optional goals that you start with but may lose depending on your actions")
+
             if (arg1 ~= nil) then
                 local name = UnitName("target")
                 local _, englishClass = UnitClass("target")
@@ -139,9 +130,6 @@ function WHC.UIShowTabContent(tabIndex, arg1)
                 local classColorCode = getColorCode(color)
                 local player = classColorCode .. name .. FONT_COLOR_CODE_CLOSE
                 WHC.Frames.UItab[tabIndex].desc1:SetText("\nListing " .. player .. "'s achievements")
-            else
-                WHC.Frames.UItab[tabIndex].desc1:SetText(
-                    "Achievements are optional goals that you start with but may lose depending on your actions")
             end
         end
     end


### PR DESCRIPTION
## Refactor
- Cleaned up all instances of `SendChatMessage()`. The 1.12 client works perfectly fine by whispering the yourself, so no need for the branching
- The `WHC.UIShowTabContent()` no longer checks for the `"Achievements"` tab twice to do logic. All the logic is in the same if-statement
- Pulled out the logic for getting the inspecting description for the achievements page to a function to increase readability.

## Change
- On 1.12 when clicking on a GM ticket and then clicking Abandon, the ticket is now deleted immediately instead of opening the support page to allow for the deletion of the ticket. This saves 1 click.