### PR TITLE
[Change] Restless Achievement - Event handling expecting status 

### DIFF
--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -1205,10 +1205,35 @@ function WHC.SetBlockTalents()
 end
 --endregion
 
---region ====== Untalented ======
-function WHC.SetBlockRestedExp()
-    -- Send event to the server. Handle the response in Events.lua
+--region ====== Restless ======
+function WHC.SendRestedXpStatusCommand()
     local msg = ".whc rested"
     SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
+end
+
+function WHC.RestedXpStatusCommandHandler(isRestedXpEnabled)
+    WhcAchievementSettings.blockRestedExp = math.abs(isRestedXpEnabled - 1)
+    WHC_SETTINGS.blockRestedExpCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRestedExp))
+end
+
+function WHC.SendRestedXpCommand()
+    local msg = ".restedxp"
+    SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
+end
+
+function WHC.RestedXpCommandHandler(serverMessage)
+    local _, _, status = string.find(serverMessage, "^Rested XP is now (%l+)\.")
+    if not status then
+        return
+    end
+
+    if status == "disabled" then
+        WhcAchievementSettings.blockRestedExp = 1
+    end
+    if status == "enabled" then
+        WhcAchievementSettings.blockRestedExp = 0
+    end
+
+    WHC_SETTINGS.blockRestedExpCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRestedExp))
 end
 --endregion

--- a/AchievementHelpers.lua
+++ b/AchievementHelpers.lua
@@ -1206,34 +1206,18 @@ end
 --endregion
 
 --region ====== Restless ======
-function WHC.SendRestedXpStatusCommand()
+function WHC.SendGetRestedXpStatusCommand()
     local msg = ".whc rested"
     SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
 end
 
-function WHC.RestedXpStatusCommandHandler(isRestedXpEnabled)
+function WHC.OnRestedXpStatusReceived(isRestedXpEnabled)
     WhcAchievementSettings.blockRestedExp = math.abs(isRestedXpEnabled - 1)
     WHC_SETTINGS.blockRestedExpCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRestedExp))
 end
 
-function WHC.SendRestedXpCommand()
+function WHC.SendToggleRestedXpCommand()
     local msg = ".restedxp"
     SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-end
-
-function WHC.RestedXpCommandHandler(serverMessage)
-    local _, _, status = string.find(serverMessage, "^Rested XP is now (%l+)\.")
-    if not status then
-        return
-    end
-
-    if status == "disabled" then
-        WhcAchievementSettings.blockRestedExp = 1
-    end
-    if status == "enabled" then
-        WhcAchievementSettings.blockRestedExp = 0
-    end
-
-    WHC_SETTINGS.blockRestedExpCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRestedExp))
 end
 --endregion

--- a/Events.lua
+++ b/Events.lua
@@ -16,7 +16,7 @@ playerLogin:SetScript("OnEvent", function(self, event)
     local msg = ".whc version " .. GetAddOnMetadata("WOW_HC", "Version")
     SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
 
-    WHC.SetBlockRestedExp()
+    WHC.SendRestedXpStatusCommand()
 end)
 
 local function createAchievementButton(frame, name)
@@ -288,11 +288,7 @@ local function handleChatEvent(arg1)
         local result = string.gsub(arg1, "^::whc::restedxp:status:", "")
         result = tonumber(result)
 
-        local isRestedExpBlocked = math.abs(result - 1)
-        if WhcAchievementSettings.blockRestedExp ~= isRestedExpBlocked then
-            local msg = ".restedxp"
-            SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
-        end
+        WHC.RestedXpStatusCommandHandler(result)
 
         return 0
     end
@@ -375,29 +371,13 @@ local function handleChatEvent(arg1)
 end
 
 local function handleMonsterChatEvent(arg1)
-    if (strfind(string.lower(arg1), "has died at level")) then
+    if (string.find(string.lower(arg1), "has died at level")) then
 
         WHC.LogDeathMessage(arg1)
         return 0
     end
 
     return 1
-end
-
-local function synchronizeRestlessSettingWithServer(message)
-    local _, _, status = string.find(message, "^Rested XP is now (%l+)\.")
-    if not status then
-        return
-    end
-
-    if status == "disabled" then
-        WhcAchievementSettings.blockRestedExp = 1
-    end
-    if status == "enabled" then
-        WhcAchievementSettings.blockRestedExp = 0
-    end
-
-    WHC_SETTINGS.blockRestedExpCheckbox:SetChecked(WHC.CheckedValue(WhcAchievementSettings.blockRestedExp))
 end
 
 if (RETAIL == 1) then
@@ -412,7 +392,7 @@ if (RETAIL == 1) then
             return true
         end
 
-        synchronizeRestlessSettingWithServer(message)
+        WHC.RestedXpCommandHandler(message)
     end)
 else
     xx_ChatFrame_OnEvent = ChatFrame_OnEvent
@@ -423,7 +403,7 @@ else
                 return
             end
 
-            synchronizeRestlessSettingWithServer(arg1)
+            WHC.RestedXpCommandHandler(arg1)
         end
 
         if (event == "CHAT_MSG_RAID_BOSS_EMOTE" or event == "CHAT_MSG_MONSTER_EMOTE") then

--- a/Events.lua
+++ b/Events.lua
@@ -16,7 +16,8 @@ playerLogin:SetScript("OnEvent", function(self, event)
     local msg = ".whc version " .. GetAddOnMetadata("WOW_HC", "Version")
     SendChatMessage(msg, "WHISPER", GetDefaultLanguage(), UnitName("player"));
 
-    WHC.SendRestedXpStatusCommand()
+    -- Initialize UI to same state as server
+    WHC.SendGetRestedXpStatusCommand()
 end)
 
 local function createAchievementButton(frame, name)
@@ -288,7 +289,7 @@ local function handleChatEvent(arg1)
         local result = string.gsub(arg1, "^::whc::restedxp:status:", "")
         result = tonumber(result)
 
-        WHC.RestedXpStatusCommandHandler(result)
+        WHC.OnRestedXpStatusReceived(result)
 
         return 0
     end
@@ -388,11 +389,7 @@ if (RETAIL == 1) then
         handleMonsterChatEvent(message)
     end)
     ChatFrame_AddMessageEventFilter("CHAT_MSG_SYSTEM", function(frame, event, message, sender, ...)
-        if handleChatEvent(message) == 0 then
-            return true
-        end
-
-        WHC.RestedXpCommandHandler(message)
+        return handleChatEvent(message) == 0
     end)
 else
     xx_ChatFrame_OnEvent = ChatFrame_OnEvent
@@ -402,8 +399,6 @@ else
             if handleChatEvent(arg1) == 0 then
                 return
             end
-
-            WHC.RestedXpCommandHandler(arg1)
         end
 
         if (event == "CHAT_MSG_RAID_BOSS_EMOTE" or event == "CHAT_MSG_MONSTER_EMOTE") then

--- a/Init.lua
+++ b/Init.lua
@@ -156,7 +156,6 @@ WHC:SetScript("OnEvent", function(self, event, addonName)
     WHC.SetBlockTrainSkill()
     WHC.SetBlockQuests()
     WHC.SetWarningOnlyKill()
-    -- WHC.SetBlockRestedExp() is called after the `PLAYER_LOGIN` event when the chat is ready
     if RETAIL == 0 then
         WHC.SetBlockEquipItems()
     end

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -249,7 +249,7 @@ function WHC.Tab_Settings(content)
 
     WHC_SETTINGS.blockRestedExpCheckbox = createSettingsCheckBox(scrollContent, string.format("%s Achievement: Block rested exp", WHC.Achievements.RESTLESS.itemLink))
     WHC_SETTINGS.blockRestedExpCheckbox:SetScript("OnClick", function()
-        WHC.SendRestedXpCommand()
+        WHC.SendToggleRestedXpCommand()
     end)
 
     if RETAIL == 0 then

--- a/Tabs/Settings.lua
+++ b/Tabs/Settings.lua
@@ -249,8 +249,7 @@ function WHC.Tab_Settings(content)
 
     WHC_SETTINGS.blockRestedExpCheckbox = createSettingsCheckBox(scrollContent, string.format("%s Achievement: Block rested exp", WHC.Achievements.RESTLESS.itemLink))
     WHC_SETTINGS.blockRestedExpCheckbox:SetScript("OnClick", function()
-        WhcAchievementSettings.blockRestedExp = getCheckedValueAndPlaySound(WHC_SETTINGS.blockRestedExpCheckbox)
-        WHC.SetBlockRestedExp()
+        WHC.SendRestedXpCommand()
     end)
 
     if RETAIL == 0 then


### PR DESCRIPTION
Here is the addon logic for when the server responds with the rested xp status on calls to `.rested` and `.restedxp`

## Not Tested - Waiting on PTR