### PR TITLE
Adding simple lookup for different tabs

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -262,6 +262,8 @@ function WHC.InitializeUI()
     -- Slash command to toggle the frame
     SLASH_WOWHC1 = "/wowhc"
     SlashCmdList["WOWHC"] = function(msg)
-        WHC.UIShowTabContent(WHC.lastTab)
+        local tab = WHC.TAB_KEYS[string.upper(msg)] or WHC.TAB.lastTab
+
+        WHC.UIShowTabContent(tab)
     end
 end

--- a/UI.lua
+++ b/UI.lua
@@ -262,7 +262,7 @@ function WHC.InitializeUI()
     -- Slash command to toggle the frame
     SLASH_WOWHC1 = "/wowhc"
     SlashCmdList["WOWHC"] = function(msg)
-        local tab = WHC.TAB_KEYS[string.upper(msg)] or WHC.TAB.lastTab
+        local tab = WHC.TAB[string.upper(msg)] or WHC.TAB.lastTab
 
         WHC.UIShowTabContent(tab)
     end


### PR DESCRIPTION
This is very naive implementation of lookup.

I am not removing extra spaces, or giving error messages back if the command is incorrect. If you want more input validation from then I can add whitespace trim and error messages on wrong arguments.

I am 99% sure it works based on how other addons has implemented similar logic, but I have not tested it as I am not at home.